### PR TITLE
Change default tsconfig.json path to src/tsconfig.app.json

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -1,6 +1,6 @@
 {
   "globals": {
-    "__TS_CONFIG__": "src/tsconfig.json",
+    "__TS_CONFIG__": "src/tsconfig.app.json",
     "__TRANSFORM_HTML__": true
   },
   "transform": {


### PR DESCRIPTION
The path `src/tsconfig.json` does [not exist](https://github.com/angular/angular-cli/tree/master/packages/%40angular/cli/blueprints/ng/files/__path__) anymore in an app created by Angular CLI. 

It has changed to `src/tsconfig.app.json` resulting in the error below when trying to follow the installation steps described in the blog post. 

```
 FAIL  src/app/app.component.spec.ts
  ● Test suite failed to run

    ENOENT: no such file or directory, open '/path/to/angular-cli-jest/src/tsconfig.json'
```