### PR TITLE
Template preprocessor path fix

### DIFF
--- a/__tests__/preprocessor.test.js
+++ b/__tests__/preprocessor.test.js
@@ -1,6 +1,4 @@
-const {
-  process
-} = require('../preprocessor');
+const {process} = require('../preprocessor');
 
 const sources = [
   `@Component({
@@ -40,7 +38,7 @@ const config = {
 
 sources.forEach(source => {
   test(`works with ${source}`, () => {
-    var result = process(source, '', config);
+    const result = process(source, '', config);
     expect(result).toMatch('styles: []');
     expect(result).toMatch('template: require(\'./media-box-h0.component.html\')');
   });

--- a/__tests__/preprocessor.test.js
+++ b/__tests__/preprocessor.test.js
@@ -1,4 +1,6 @@
-const {process} = require('../preprocessor');
+const {
+  process
+} = require('../preprocessor');
 
 const sources = [
   `@Component({
@@ -40,6 +42,6 @@ sources.forEach(source => {
   test(`works with ${source}`, () => {
     var result = process(source, '', config);
     expect(result).toMatch('styles: []');
-    expect(result).toMatch('template: \'./media-box-h0.component.html\'');
+    expect(result).toMatch('template: require(\'./media-box-h0.component.html\')');
   });
 });

--- a/__tests__/preprocessor.test.js
+++ b/__tests__/preprocessor.test.js
@@ -14,14 +14,14 @@ const sources = [
 })`,
   `@Component({
   selector: 'xc-media-box-h0',
-  templateUrl: './media-box-h0.component.html',
+  templateUrl: 'media-box-h0.component.html',
   styleUrls: [
     '../media-box.component.scss',
   ],
 })`,
   `@Component({
   selector: 'xc-media-box-h0',
-  templateUrl: './media-box-h0.component.html',
+  templateUrl: 'media-box-h0.component.html',
   styleUrls: [
     '../media-box.component.scss',
     './media-box-h0.component.scss'
@@ -38,6 +38,8 @@ const config = {
 
 sources.forEach(source => {
   test(`works with ${source}`, () => {
-    expect(process(source, '', config)).toMatch('styles: []');
+    var result = process(source, '', config);
+    expect(result).toMatch('styles: []');
+    expect(result).toMatch('template: \'./media-box-h0.component.html\'');
   });
 });

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,5 +1,5 @@
 const {process} = require('ts-jest/preprocessor.js');
-const TEMPLATE_URL_REGEX = /templateUrl:\s*('|")(.*)('|")/g;
+const TEMPLATE_URL_REGEX = /templateUrl:\s*('|")(\.\/){0,1}(.*)('|")/g;
 const STYLE_URLS_REGEX = /styleUrls:\s*\[\s*((?:'|").*\s*(?:'|")).*\s*.*\]/g;
 
 module.exports.process = (src, path, config) => {
@@ -7,7 +7,7 @@ module.exports.process = (src, path, config) => {
   // and `styleUrls: ['']` with `styles: []`
   return process(
     src
-      .replace(TEMPLATE_URL_REGEX, 'template: require($1./$2$3)')
+      .replace(TEMPLATE_URL_REGEX, 'template: require($1./$3$4)')
       .replace(STYLE_URLS_REGEX, 'styles: []'),
     path,
     config


### PR DESCRIPTION
Fixed template preprocessor regex to retain "./" correctly.  For instance, previously it would replace "./mytemplate.html" with "././mytemplate.html".  Now it works as follows:

templateUrl: './component.html' => template: require('./component.html')
templateUrl: 'component2.html' => template: require('./component.html')
templateUrl: '../component2.html' => template: require('./../component.html')
templateUrl: '../../component2.html' => template: require('./../../component.html')
templateUrl: 'test/component2.html' => template: require('./test/component.html')
templateUrl: './test/component2.html' => template: require('./test/component.html')