### PR TITLE
__TS_CONFIG__ deprecation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 {
   "globals": {
     "ts-jest": {
-        "tsConfigFile": "src/tsconfig.spec.json"
-      }
+      "tsConfigFile": "src/tsconfig.spec.json"
+    }
     "__TRANSFORM_HTML__": true
   },
   "transform": {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
   "globals": {
     "ts-jest": {
       "tsConfigFile": "src/tsconfig.spec.json"
-    }
+    },
     "__TRANSFORM_HTML__": true
   },
   "transform": {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 ```json
 {
   "globals": {
-    "__TS_CONFIG__": "src/tsconfig.spec.json",
+    "ts-jest": {
+        "tsConfigFile": "src/tsconfig.spec.json"
+      }
     "__TRANSFORM_HTML__": true
   },
   "transform": {
@@ -139,7 +141,9 @@ Override `globals` object in Jest config:
 {
   "jest": {
     "globals": {
-      "__TS_CONFIG__": "src/tsconfig.custom.json",
+     "ts-jest": {
+        "tsConfigFile": "src/tsconfig.custom.json"
+      }, 
       "__TRANSFORM_HTML__": true
     }
   }

--- a/__tests__/preprocessor.test.js
+++ b/__tests__/preprocessor.test.js
@@ -32,7 +32,7 @@ const sources = [
 const config = {
   globals: {
     'ts-jest': {
-         tsConfigFile: 'example/src/tsconfig.spec.json'
+      tsConfigFile: 'example/src/tsconfig.spec.json'
     },
     __TRANSFORM_HTML__: true
   }

--- a/__tests__/preprocessor.test.js
+++ b/__tests__/preprocessor.test.js
@@ -31,7 +31,9 @@ const sources = [
 
 const config = {
   globals: {
-    __TS_CONFIG__: 'example/src/tsconfig.spec.json',
+    'ts-jest': {
+         tsConfigFile: 'example/src/tsconfig.spec.json'
+    },
     __TRANSFORM_HTML__: true
   }
 };

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -1,8 +1,8 @@
 {
   "globals": {
     "ts-jest": {
-        "tsConfigFile": "src/tsconfig.spec.json"
-      },
+      "tsConfigFile": "src/tsconfig.spec.json"
+    },
     "__TRANSFORM_HTML__": true
   },
   "transform": {

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -1,6 +1,8 @@
 {
   "globals": {
-    "__TS_CONFIG__": "src/tsconfig.spec.json",
+    "ts-jest": {
+        "tsConfigFile": "src/tsconfig.spec.json"
+      },
     "__TRANSFORM_HTML__": true
   },
   "transform": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3",
   "dependencies": {
     "jest-zone-patch": "^0.0.7",
-    "ts-jest": "^20.0.0"
+    "ts-jest": "^20.0.7"
   },
   "devDependencies": {
     "jest": "^20.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preset-angular",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Jest preset configuration for Angular projects",
   "main": "index.js",
   "repository": "git@github.com:thymikee/jest-preset-angular.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,10 +2106,6 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-json-comments@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -2160,9 +2156,9 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-ts-jest@^20.0.6:
-  version "20.0.6"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-20.0.6.tgz#39c2810c05d6f6908dac15929dae206b494b73f4"
+ts-jest@^20.0.7:
+  version "20.0.7"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-20.0.7.tgz#82c99b9163f8c0a864a2b221238202fa1e623c26"
   dependencies:
     "@types/babel-core" "^6.7.14"
     babel-core "^6.24.1"
@@ -2174,15 +2170,7 @@ ts-jest@^20.0.6:
     jest-util "^20.0.0"
     pkg-dir "^2.0.0"
     source-map-support "^0.4.4"
-    tsconfig "^6.0.0"
     yargs "^8.0.1"
-
-tsconfig@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
-  dependencies:
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
ts-jest 20.0.7 has deprecated the __TS_CONFIG__ global parameter, with a new 
"ts-jest": {
        "tsConfigFile": "src/tsconfig.spec.json"
 }
The PR fixes the preset, tests and readme to support this. 