### PR TITLE
be a bit more specific with the moduleNameMapper regexps

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -17,10 +17,10 @@
   ],
   "mapCoverage": true,
   "moduleNameMapper": {
-    "src/(.*)": "<rootDir>/src/$1",
-    "app/(.*)": "<rootDir>/src/app/$1",
-    "assets/(.*)": "<rootDir>/src/assets/$1",
-    "environments/(.*)": "<rootDir>/src/environments/$1"
+    "^src/(.*)": "<rootDir>/src/$1",
+    "^app/(.*)": "<rootDir>/src/app/$1",
+    "^assets/(.*)": "<rootDir>/src/assets/$1",
+    "^environments/(.*)": "<rootDir>/src/environments/$1"
   },
   "transformIgnorePatterns": [
     "node_modules/(?!@ngrx)"


### PR DESCRIPTION
If you use the jest-preset-angular for an ionic project, there they have an app.ts, and the moduleNameMapper maps it to an incorrect location.