### PR TITLE
add default html to test environment

### DIFF
--- a/testEnvironment.js
+++ b/testEnvironment.js
@@ -12,10 +12,8 @@ class JSDOMEnvironment {
   constructor(config) {
     // lazy require
     const {JSDOM} = require('jsdom');
-
-    const html = '<!DOCTYPE HTML><html lang="en"><head><title>Test Environment</title></head><body></body></html>'
     
-    this.document = new JSDOM(html, {
+    this.document = new JSDOM('<!doctype html>', {
       url: config.testURL,
       runScripts: 'dangerously'
     });

--- a/testEnvironment.js
+++ b/testEnvironment.js
@@ -13,7 +13,9 @@ class JSDOMEnvironment {
     // lazy require
     const {JSDOM} = require('jsdom');
 
-    this.document = new JSDOM(undefined, {
+    const html = '<!DOCTYPE HTML><html lang="en"><head><title>Test Environment</title></head><body></body></html>'
+    
+    this.document = new JSDOM(html, {
       url: config.testURL,
       runScripts: 'dangerously'
     });


### PR DESCRIPTION
In order to fix Angular Material tests, a default HTML shell should be used

This change fixes the following console warnings

```shell
 PASS  src/client/app/+admin/admin.component.spec.ts
  ● Console

    console.warn node_modules/@angular/material/bundles/material.umd.js:206
      Current document does not have a doctype. This may cause some Angular Material components not to behave as expected.
    console.warn node_modules/@angular/material/bundles/material.umd.js:206
      Current document does not have a doctype. This may cause some Angular Material components not to behave as expected.

```

<img width="1084" alt="screen shot 2017-10-05 at 12 33 40 pm" src="https://user-images.githubusercontent.com/6701211/31241428-71eccef8-a9c9-11e7-81c2-5f238e78bfc3.png">
