### PR TITLE
Protect against potentially undefined nodes.

### DIFF
--- a/AngularSnapshotSerializer.js
+++ b/AngularSnapshotSerializer.js
@@ -26,7 +26,7 @@ const print = (val, print, indent, opts, colors) => {
 
   const componentName = val.componentRef._elDef.element.name;
   const nodes = (val.componentRef._view.nodes || [])
-    .filter(node => node.hasOwnProperty('renderElement'))
+    .filter(node => node && node.hasOwnProperty('renderElement'))
     .map(node => Array.from(node.renderElement.childNodes).map(print).join(''))
     .join(opts.edgeSpacing);
 


### PR DESCRIPTION
I was seeing some strange behavior popping up, where `node` was `undefined` for some of my components, which was errors being thrown about `hasOwnProperty` being called on `undefined`.

I don't really know a whole lot about the internals of Angular components, however, I did recently upgrade to Angular 5 so I suspect this might have something to do with that.

Inspecting the `val.componentRef._view.nodes` shows me that there are in fact multiple nodes in the array, and one is `undefined`. I tried simplifying my template down to a single `<div></div>`, but no luck.

All the tests are passing, but please let me know if there are any red flags around this sort of change.