### PR TITLE
Remove testRegex out of preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog (master)
 
-* Chore: Change `testRegex` to `testMatch` ([#130](https://github.com/thymikee/jest-preset-angular/pull/130))
+* Chore: Change `testRegex` to `testMatch` ([#131](https://github.com/thymikee/jest-preset-angular/pull/131))
 
 ### v5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog (master)
 
+* Chore: Remove `testRegex` out of the preset config, by default Jest already set `testMatch` ([#130](https://github.com/thymikee/jest-preset-angular/pull/130))
+
 ### v5.2.0
 
 * Chore: Upgrade ts-jest and remove `mapCoverage` from `jest-preset` (requires `jest@^22.4.0` as a dependency now) ([#127](https://github.com/thymikee/jest-preset-angular/pull/127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog (master)
 
-* Chore: Remove `testRegex` out of the preset config, by default Jest already set `testMatch` ([#130](https://github.com/thymikee/jest-preset-angular/pull/130))
+* Chore: Change `testRegex` to `testMatch` ([#130](https://github.com/thymikee/jest-preset-angular/pull/130))
 
 ### v5.2.0
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
   "testMatch": [
-    "(/__tests__/.*|\\.(test|spec))\\.(ts|js)$"
+    "**/__tests__/**/*.+(ts|js)?(x)",
+    "**/?(*.)+(spec|test).+(ts|js)?(x)"
   ],
   "moduleFileExtensions": [
     "ts",

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 * `<rootDir>` is a special syntax for root of your project (here by default it's project's root /)
 * we're using some `"globals"` to pass information about where our tsconfig.json file is that we'd like to be able to transform HTML files through ts-jest
 * `"transform"` – run every TS, JS, or HTML file through so called *preprocessor* (we'll get there); this lets Jest understand non-JS syntax
-* `"testMatch"` – we want to run Jest on files that matches this regex
+* `"testMatch"` – we want to run Jest on files that matches this glob
 * `"moduleFileExtensions"` – our modules are TypeScript and JavaScript files
 * `"moduleNameMapper"` – if you're using absolute imports here's how to tell Jest where to look for them; uses regex
 * `"setupTestFrameworkScriptFile"` – this is the heart of our config, in this file we'll setup and patch environment within tests are running

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
   "transform": {
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
+  "testMatch": [
+    "(/__tests__/.*|\\.(test|spec))\\.(ts|js)$"
+  ],
   "moduleFileExtensions": [
     "ts",
     "js",
@@ -65,6 +68,7 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 * `<rootDir>` is a special syntax for root of your project (here by default it's project's root /)
 * we're using some `"globals"` to pass information about where our tsconfig.json file is that we'd like to be able to transform HTML files through ts-jest
 * `"transform"` – run every TS, JS, or HTML file through so called *preprocessor* (we'll get there); this lets Jest understand non-JS syntax
+* `"testMatch"` – we want to run Jest on files that matches this regex
 * `"moduleFileExtensions"` – our modules are TypeScript and JavaScript files
 * `"moduleNameMapper"` – if you're using absolute imports here's how to tell Jest where to look for them; uses regex
 * `"setupTestFrameworkScriptFile"` – this is the heart of our config, in this file we'll setup and patch environment within tests are running

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
   "testMatch": [
-    "**/__tests__/**/*.(ts|js)?(x)",
-    "**/+(*.)(spec|test).(ts|js)?(x)"
+    "**/__tests__/**/*.+(ts|js)?(x)",
+    "**/+(*.)+(spec|test).+(ts|js)?(x)"
   ],
   "moduleFileExtensions": [
     "ts",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
   "transform": {
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
-  "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|js)$",
   "moduleFileExtensions": [
     "ts",
     "js",
@@ -66,7 +65,6 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 * `<rootDir>` is a special syntax for root of your project (here by default it's project's root /)
 * we're using some `"globals"` to pass information about where our tsconfig.json file is that we'd like to be able to transform HTML files through ts-jest
 * `"transform"` – run every TS, JS, or HTML file through so called *preprocessor* (we'll get there); this lets Jest understand non-JS syntax
-* `"testRegex"` – we want to run Jest on files that matches this regex
 * `"moduleFileExtensions"` – our modules are TypeScript and JavaScript files
 * `"moduleNameMapper"` – if you're using absolute imports here's how to tell Jest where to look for them; uses regex
 * `"setupTestFrameworkScriptFile"` – this is the heart of our config, in this file we'll setup and patch environment within tests are running

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
   "testMatch": [
-    "**/__tests__/**/*.+(ts|js)?(x)",
-    "**/?(*.)+(spec|test).+(ts|js)?(x)"
+    "**/__tests__/**/*.(ts|js)?(x)",
+    "**/+(*.)(spec|test).(ts|js)?(x)"
   ],
   "moduleFileExtensions": [
     "ts",

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -8,7 +8,6 @@
   "transform": {
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
-  "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|js)$",
   "moduleFileExtensions": [
     "ts",
     "js",

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -9,8 +9,8 @@
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
   "testMatch": [
-    "**/__tests__/**/*.(ts|js)?(x)",
-    "**/+(*.)(spec|test).(ts|js)?(x)"
+    "**/__tests__/**/*.+(ts|js)?(x)",
+    "**/+(*.)+(spec|test).+(ts|js)?(x)"
   ],
   "moduleFileExtensions": [
     "ts",

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -9,7 +9,8 @@
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
   "testMatch": [
-    "(/__tests__/.*|\\.(test|spec))\\.(ts|js)$"
+    "**/__tests__/**/*.+(ts|js)?(x)",
+    "**/?(*.)+(spec|test).+(ts|js)?(x)"
   ],
   "moduleFileExtensions": [
     "ts",

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -8,6 +8,9 @@
   "transform": {
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
+  "testMatch": [
+    "(/__tests__/.*|\\.(test|spec))\\.(ts|js)$"
+  ],
   "moduleFileExtensions": [
     "ts",
     "js",

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -9,8 +9,8 @@
     "^.+\\.(ts|js|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js"
   },
   "testMatch": [
-    "**/__tests__/**/*.+(ts|js)?(x)",
-    "**/?(*.)+(spec|test).+(ts|js)?(x)"
+    "**/__tests__/**/*.(ts|js)?(x)",
+    "**/+(*.)(spec|test).(ts|js)?(x)"
   ],
   "moduleFileExtensions": [
     "ts",


### PR DESCRIPTION
Jest default set up testMatch to get all the test files to run. Removing testRegex out of the preset will bring flexibility to the users to set up their own testMatch/testRegex.