### PR TITLE
Revert /dist/zone.js import to fix issues/96

### DIFF
--- a/setupJest.js
+++ b/setupJest.js
@@ -2,7 +2,7 @@
 
 require('core-js/es6/reflect');
 require('core-js/es7/reflect');
-require('zone.js/dist/zone.js');
+require('zone.js');
 require('zone.js/dist/proxy.js');
 require('zone.js/dist/sync-test');
 require('zone.js/dist/async-test');


### PR DESCRIPTION
This fixes the error that happens when you have 3rd. party libraries also using zone.js (for both node and browser). 

https://github.com/thymikee/jest-preset-angular/issues/96.
