### PR TITLE
Breaking: AngularSnapshotSerializer - Remove additional whitespace

### DIFF
--- a/AngularSnapshotSerializer.js
+++ b/AngularSnapshotSerializer.js
@@ -53,7 +53,7 @@ const print = (val, print, indent, opts, colors) => {
     '\n</' +
     componentName +
     '>'
-  );
+  ).replace(/\n\s+\n/g, '\n');
 };
 
 const test = val =>


### PR DESCRIPTION
Creating snapshot tests with nested components resulted in a lot of empty lines in snapshots for me, which was not fixed entirely by [setting compiler options](https://github.com/thymikee/jest-preset-angular#removing-empty-lines-and-white-spaces-in-component-snaphots).

With the change in this pull request, any empty lines will be removed while preserving any indents.

This obviously is a breaking change as this will break any test that expects snapshots with empty lines.
If this feature won't be activated by default, we might want to make it at least optional/enabled by a config, as I think that it improves the readablity of snapshots a lot.