### PR TITLE
support backtick quoted templateUrl

### DIFF
--- a/__tests__/preprocessor.test.js
+++ b/__tests__/preprocessor.test.js
@@ -55,7 +55,19 @@ const sources = [
     '../media-box.component.scss',
     './media-box-h0.component.scss'
   ],
-})`
+})`,
+  // double quote
+  `@Component({
+  selector: 'xc-media-box-h0',
+  templateUrl: "./media-box-h0.component.html",
+  styleUrls: [ '../media-box.component.scss' ],
+})`,
+  // backtick
+  `@Component({
+  selector: 'xc-media-box-h0',
+  templateUrl: \`./media-box-h0.component.html\`,
+  styleUrls: [ '../media-box.component.scss' ],
+})`,
 ];
 
 const config = {
@@ -72,7 +84,7 @@ sources.forEach(source => {
     const result = process(source, '', config);
     expect(result).toMatch('styles: []');
     expect(result).toMatch(
-      "template: require('./media-box-h0.component.html')"
+      /template: require\(['"`]\.\/media-box-h0\.component\.html['"`]\)/
     );
   });
 });

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,5 +1,5 @@
 const process = require('ts-jest').process;
-const TEMPLATE_URL_REGEX = /templateUrl\s*:\s*('|")(\.\/){0,}(.*)('|")/g;
+const TEMPLATE_URL_REGEX = /templateUrl\s*:\s*('|"|`)(\.\/){0,}(.*)('|"|`)/g;
 const STYLE_URLS_REGEX = /styleUrls\s*:\s*\[[^\]]*\]/g;
 const ESCAPE_TEMPLATE_REGEX = /(\${|\`)/g;
 


### PR DESCRIPTION
As explained in readme, the current approach to processing `templateUrl` is a scrappy regex. However, the current regex only supports single quote and double quote.

This PR add backtick support to it.