### PR TITLE
Fix README.md to include moduleNameMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 {
   "jest": {
     "preset": "jest-preset-angular",
-    "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts"
+    "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts",
+    "moduleNameMapper": {
+      "@lib/(.*)": "<rootDir>/src/lib/$1"
+    }
   }
 }
 ```


### PR DESCRIPTION
Without the moduleNameMapper config option, jest will not run on the current version of angular CLI (you will get a `SyntaxError: Unexpected string`).  We discovered that this is necessary through testing the various differences between a newly generated angular CLI project and the `/example` project in this repo.

Fixes #181