### PR TITLE
Add HeroesComponent example with mocked service provider (#110)

### DIFF
--- a/example/src/app/app.module.ts
+++ b/example/src/app/app.module.ts
@@ -7,13 +7,15 @@ import { AppComponent } from './app.component';
 import { CalcComponent } from './calc/calc.component';
 import { SimpleComponent } from './simple/simple.component';
 import { OnPushComponent } from './on-push/on-push.component';
+import { HeroesComponent } from './heroes/heroes.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     CalcComponent,
     SimpleComponent,
-    OnPushComponent
+    OnPushComponent,
+    HeroesComponent
   ],
   imports: [
     BrowserModule,

--- a/example/src/app/heroes/heroes.component.css
+++ b/example/src/app/heroes/heroes.component.css
@@ -1,0 +1,1 @@
+/* HeroesComponent's private CSS styles */

--- a/example/src/app/heroes/heroes.component.html
+++ b/example/src/app/heroes/heroes.component.html
@@ -1,0 +1,7 @@
+<h2>My Heroes</h2>
+
+<ul class="heroes">
+  <li *ngFor="let hero of heroes">
+    <span class="badge">{{hero.id}}</span> {{hero.name}}
+  </li>
+</ul>

--- a/example/src/app/heroes/heroes.component.spec.ts
+++ b/example/src/app/heroes/heroes.component.spec.ts
@@ -1,0 +1,55 @@
+import {async, ComponentFixture} from '@angular/core/testing';
+import {HeroesComponent} from './heroes.component';
+import {ConfigureFn, configureTests} from '@lib/testing';
+import {Hero} from '../service/hero';
+import {HeroService} from '../service/hero.service';
+import {Subject} from 'rxjs';
+
+describe('HeroesComponent', () => {
+  let component: HeroesComponent;
+  let fixture: ComponentFixture<HeroesComponent>;
+
+  const mockHeroesSubject = new Subject<Hero[]>();
+  const mockHeroService = {
+    getHeroes: jest.fn(() => mockHeroesSubject)
+  };
+
+  const allHeroes: Hero[] = [
+    {
+      id: 1,
+      name: 'Test hero 1',
+    },
+    {
+      id: 2,
+      name: 'Test hero 2',
+    }
+  ];
+
+  beforeEach(async(() => {
+    const configure: ConfigureFn = testBed => {
+      testBed.configureTestingModule({
+        declarations: [HeroesComponent],
+        providers: [{provide: HeroService, useValue: mockHeroService}]
+      });
+    };
+
+    configureTests(configure).then(testBed => {
+      fixture = testBed.createComponent(HeroesComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+  }));
+
+  afterEach(() => {
+    mockHeroesSubject.complete();
+  });
+
+  it('should display a list of all heroes', () => {
+    mockHeroesSubject.next(allHeroes);
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement;
+    expect(el.textContent).toContain('Test hero 1');
+    expect(el.textContent).toContain('Test hero 2');
+  });
+});

--- a/example/src/app/heroes/heroes.component.ts
+++ b/example/src/app/heroes/heroes.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+
+import { Hero } from '../service/hero';
+import { HeroService } from '../service/hero.service';
+
+@Component({
+  selector: 'app-heroes',
+  templateUrl: './heroes.component.html',
+  styleUrls: ['./heroes.component.css']
+})
+export class HeroesComponent implements OnInit {
+  heroes: Hero[];
+
+  constructor(private heroService: HeroService) { }
+
+  ngOnInit() {
+    this.getHeroes();
+  }
+
+  getHeroes(): void {
+    this.heroService.getHeroes()
+      .subscribe(heroes => this.heroes = heroes);
+  }
+}

--- a/example/src/app/service/hero.service.spec.ts
+++ b/example/src/app/service/hero.service.spec.ts
@@ -4,7 +4,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 
 import { heroesUrl, HeroService } from './hero.service'
 
-describe('Service: GoogleBooks', () => {
+describe('Service: HeroService', () => {
   let service: HeroService
   let backend: HttpTestingController
 

--- a/example/src/app/service/hero.service.spec.ts
+++ b/example/src/app/service/hero.service.spec.ts
@@ -13,6 +13,17 @@ describe('Service: HeroService', () => {
     name: 'Test hero',
   }
 
+  const expectedDataAll = [
+    {
+      id: 1,
+      name: 'Test hero 1'
+    },
+    {
+      id: 2,
+      name: 'Test hero 2'
+    }
+  ]
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -38,6 +49,20 @@ describe('Service: HeroService', () => {
 
   it('should create an instance successfully', () => {
     expect(service).toBeDefined()
+  })
+
+  it('should call the GET heroes api and return all results', () => {
+    let actualDataAll = {}
+
+    service.getHeroes().subscribe(data => actualDataAll = data)
+
+    backend.expectOne((req: HttpRequest<any>) => {
+      return req.url === `${heroesUrl}`
+        && req.method === 'GET'
+    }, `GET all hero data from ${heroesUrl}`)
+      .flush(expectedDataAll)
+
+    expect(actualDataAll).toEqual(expectedDataAll)
   })
 
   it('should call the GET hero api and return the result', () => {

--- a/example/src/app/service/hero.service.ts
+++ b/example/src/app/service/hero.service.ts
@@ -13,6 +13,14 @@ export class HeroService {
 
   constructor(private http: HttpClient) {}
 
+  /** GET heroes from the server */
+  getHeroes(): Observable<Hero[]> {
+    return this.http.get<Hero>(heroesUrl)
+      .pipe(
+        catchError(err => this.handleError(err, 'getHero')),
+      )
+  }
+
   /** GET hero by id. Will 404 if id not found */
   getHero(id: number): Observable<Hero> {
     const params = new HttpParams().set('id', id.toString())

--- a/example/tslint.json
+++ b/example/tslint.json
@@ -12,7 +12,6 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true, "rxjs"],
     "import-spacing": true,
     "indent": [
       true,


### PR DESCRIPTION
Related to Issue #110
An example of how to mock a service provider's return values using `jest.fn()` and rxjs' `Subject` without having to bother with mocking low-level HTTP responses. 
I placed the component in its own `heroes` folder which is kind of awkward since the Hero model and service are in the more generic `service` folder, but I didn't want to take too many liberties in moving stuff around.  

Other small changes:
* Removed `'rxjs'` from the import-blacklist as it was causing linter warnings on existing code.
* Fixed incorrect describe name on existing HeroService spec.