### PR TITLE
chore: use local preset from example app

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^10.5.8",
     "codelyzer": "^4.4.3",
     "jest": "^23.5.0",
-    "jest-preset-angular": "^6.0.0",
+    "jest-preset-angular": "file:../",
     "protractor": "^5.4.0",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3744,13 +3744,12 @@ jest-mock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
 
-jest-preset-angular@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/jest-preset-angular/-/jest-preset-angular-6.0.0.tgz#f37fd4ba7984a6bb9d97efc5def510b2323ed750"
+"jest-preset-angular@file:..":
+  version "6.0.1"
   dependencies:
     "@types/jest" "^23.3.1"
     jest-zone-patch "^0.0.8"
-    ts-jest "^23.1.2"
+    ts-jest "~23.1.3"
 
 jest-regex-util@^23.3.0:
   version "23.3.0"
@@ -6729,12 +6728,14 @@ trim-right@^1.0.1:
   dependencies:
     glob "^6.0.4"
 
-ts-jest@^23.1.2:
-  version "23.1.2"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.2.tgz#34cd26f3f566924dbd385ad188ae3c3b75757f9e"
+ts-jest@~23.1.3:
+  version "23.1.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.1.4.tgz#66ac1d8d3fbf8f9a98432b11aa377aa850664b2b"
+  integrity sha512-9rCSxbWfoZxxeXnSoEIzRNr9hDIQ8iEJAWmSRsWhDHDT8OeuGfURhJQUE8jtJlkyEygs6rngH8RYtHz9cfjmEA==
   dependencies:
     closest-file-data "^0.1.4"
     fs-extra "6.0.1"
+    json5 "^0.5.0"
     lodash "^4.17.10"
 
 ts-node@^7.0.1:


### PR DESCRIPTION
This change makes the example properly test the local preset instead of published version.

cc @wtho