### PR TITLE
Transform templateUrl, styleUrls and styles everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,8 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
 * `"setupTestFrameworkScriptFile"` – this is the heart of our config, in this file we'll setup and patch environment within tests are running
 * `"transformIgnorePatterns"` – unfortunately some modules (like @ngrx ) are released as TypeScript files, not pure JavaScript; in such cases we cannot ignore them (all node_modules are ignored by default), so they can be transformed through TS compiler like any other module in our project.
 
-## [Preprocessor](https://github.com/thymikee/jest-preset-angular/blob/master/preprocessor.js)
+## [AST Transformer](https://github.com/thymikee/jest-preset-angular/blob/master/src/InlineHtmlStripStylesTransformer.ts)
 Jest doesn't run in browser nor through dev server. It uses jsdom to abstract browser environment. So we have to cheat a little and inline our templates and get rid of styles (we're not testing CSS) because otherwise Angular will try to make XHR call for our templates and fail miserably.
-
-I used a scrappy regex to accomplish this with minimum effort, but you can also write a babel plugin to make it bulletproof. And btw, don't bother about perf here – Jest heavily caches transforms. That's why you need to run Jest with `--no-cache` flag every time you change it.
 
 ## Angular testing environment setup
 

--- a/__tests__/InlineHtmlStripStylesTransformer.test.ts
+++ b/__tests__/InlineHtmlStripStylesTransformer.test.ts
@@ -88,6 +88,37 @@ const CODE_WITH_CUSTOM_DECORATOR = `
   }
 `
 
+const CODE_TEST_WITH_TEMPLATE_URL_OVERRIDE = `
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AComponent } from './a.component';
+
+describe('AComponent', () => {
+  let fixture: ComponentFixture<AComponent>,
+  instance: AComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        AComponent,
+      ],
+    }).overrideComponent(AComponent, {
+      set: {
+        templateUrl: '../__mocks__/alert-follow-stub.component.html',
+      },
+    });
+
+    fixture = TestBed.createComponent(AComponent);
+    instance = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should render the component', () => {
+    expect(fixture).toMatchSnapshot();
+  });
+});
+`
+
 
 
 const createFactory = () => {
@@ -135,6 +166,12 @@ describe('inlining template and stripping styles', () => {
 
   it('should handle all decorator assignments in differently named decorators', () => {
     const out = transpile(CODE_WITH_CUSTOM_DECORATOR)
+
+    expect(out.outputText).toMatchSnapshot()
+  })
+
+  it('should handle templateUrl in test file outside decorator', () => {
+    const out = transpile(CODE_TEST_WITH_TEMPLATE_URL_OVERRIDE)
 
     expect(out.outputText).toMatchSnapshot()
   })

--- a/__tests__/__snapshots__/InlineHtmlStripStylesTransformer.test.ts.snap
+++ b/__tests__/__snapshots__/InlineHtmlStripStylesTransformer.test.ts.snap
@@ -57,6 +57,34 @@ exports.AngularComponent = AngularComponent;
 "
 `;
 
+exports[`inlining template and stripping styles should handle templateUrl in test file outside decorator 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+var testing_1 = require(\\"@angular/core/testing\\");
+var a_component_1 = require(\\"./a.component\\");
+describe('AComponent', function () {
+    var fixture, instance;
+    beforeEach(testing_1.async(function () {
+        testing_1.TestBed.configureTestingModule({
+            declarations: [
+                a_component_1.AComponent,
+            ],
+        }).overrideComponent(a_component_1.AComponent, {
+            set: {
+                template: require('../__mocks__/alert-follow-stub.component.html'),
+            },
+        });
+        fixture = testing_1.TestBed.createComponent(a_component_1.AComponent);
+        instance = fixture.componentInstance;
+        fixture.detectChanges();
+    }));
+    it('should render the component', function () {
+        expect(fixture).toMatchSnapshot();
+    });
+});
+"
+`;
+
 exports[`inlining template and stripping styles should inline non-relative templateUrl assignment and make it relative 1`] = `
 "\\"use strict\\";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ts-jest": "~23.10.0"
   },
   "devDependencies": {
+    "@types/node": "^10.12.12",
     "jest": "^23.6.0",
     "typescript": "^3.2.1"
   },

--- a/src/InlineHtmlStripStylesTransformer.ts
+++ b/src/InlineHtmlStripStylesTransformer.ts
@@ -8,46 +8,22 @@
 
 /* 
  * IMPLEMENTATION DETAILS:
- * This transformer handles two concerns: removing styles and inlining referenced templates,
- * as they both are handled at the same location in the AST.
+ * This transformer handles two concerns: removing styles and inlining referenced templates.
  *
- * The Component can be located anywhere in a file, except inside another Angular Component.
- * The Decorator is not checked for the name 'Component', as someone might import it under
- * a different name, or have their custom, modified version of the component decorator.
- * Instead it checks for specific properties inside any class decorator.
+ * The assignments can be located anywhere in a file.
  * Caveats:
- * All properties 'templateUrl', 'styles', 'styleUrls' inside ANY decorator will be modified.
- * If the decorator content is referenced, it will not work:
- * ```ts
- * const componentArgs = {}
- * @Component(componentArgs)
- * class MyComponent { }
- * ```
+ * All properties 'templateUrl', 'styles', 'styleUrls' ANYWHERE will be modified, even if they
+ * are not used in the context of an Angular Component.
  * 
  * The AST has to look like this:
  * 
- * ClassDeclaration
- *   Decorator
- *     CallExpression
- *       ObjectLiteralExpression
- *         PropertyAssignment
- *           Identifier
- *           StringLiteral
- * 
- * Where some additional Check have to be made to identify the node as the required kind:
- * 
- * ClassDeclaration: isClassDeclaration
- *   Decorator
- *     CallExpression: isCallExpression
- *       ObjectLiteralExpression: isObjectLiteral
- *         PropertyAssignment: isPropertyAssignment
- *           Identifier: isIdentifier
- *           StringLiteral: isStringLiteral
- * 
+ * PropertyAssignment
+ *   Identifier
+ *   Initializer
  */
 
 
-// take care of importing only types, for the rest use injected `ts`
+// take care of importing only types, for the rest use injected `compilerModule`
 import TS, {
   Node,
   SourceFile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
   integrity sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ==
 
+"@types/node@^10.12.12":
+  version "10.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
+  integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
+
 "@types/node@^6.0.46":
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"


### PR DESCRIPTION
Closes #210

* Transformer became more simple
* Test was added to verify `templateUrl` gets transformed e. g. in `*.spec.ts` outside a decorator
* Updated the *Preprocessor*-section in `README.md`

:exclamation: Note that it seems the transformer was modified a lot, but basically I just removed code that only looked deep inside decorators. Now it checks everywhere for `stlyes`, `styleUrls` and `templateUrl`.