### PR TITLE
docs: add astTransformers in configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
   "globals": {
     "ts-jest": {
       "tsConfig": "<rootDir>/src/tsconfig.spec.json",
-      "stringifyContentPathRegex": "\\.html$"
+      "stringifyContentPathRegex": "\\.html$",
+      "astTransformers" :[
+        "jest-preset-angular/InlineHtmlStripStylesTransformer"
+      ]
     }
   },
   "transform": {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import './jestGlobalMocks'; // browser mocks globally available for every test
     "ts-jest": {
       "tsConfig": "<rootDir>/src/tsconfig.spec.json",
       "stringifyContentPathRegex": "\\.html$",
-      "astTransformers" :[
+      "astTransformers": [
         "jest-preset-angular/InlineHtmlStripStylesTransformer"
       ]
     }


### PR DESCRIPTION
It is not yet documented in `ts-jest`, but it [does use `require.resolve`](https://github.com/kulshekhar/ts-jest/blob/90beca89b875e947e55fc9774d10493773cbae41/src/config/config-set.ts#L711), which allows us to specify the node module following the file path.

Adding this information will prevent issues such as #217.

Fixes #217