### PR TITLE
upgrade ts-jest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/jest": "^23.3.10",
-    "ts-jest": "~23.10.0"
+    "ts-jest": "~23.10.5"
   },
   "devDependencies": {
     "@types/node": "^10.12.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,11 +2188,6 @@ jest-worker@^23.2.0:
   dependencies:
     merge-stream "^1.0.1"
 
-"jest-zone-patch@>=0.0.9 <1.0.0":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/jest-zone-patch/-/jest-zone-patch-0.0.9.tgz#ee6823317798a3ae967e82be963f0b1f80b03d3f"
-  integrity sha512-QmlUxg2NIvLHSqexS3nqQ+Kid6o+5cxYnlcTi204XwsRcBm+mVYodpe+9ddcooKR9ATBIUl4zY247Uky/PgXhw==
-
 jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
@@ -3688,7 +3683,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-jest@~23.10.0:
+ts-jest@~23.10.5:
   version "23.10.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
   integrity sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==


### PR DESCRIPTION
This resolves an issue where constructor parameters are considered code branches and are not covered by code coverage. https://github.com/istanbuljs/istanbuljs/issues/70