### PR TITLE
📝 Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ _Note: This preset does not suport AngularJS (1.x). If you want to set up Jest w
 
 ```bash
 yarn add -D jest jest-preset-angular
+# or
+npm install -D jest jest-preset-angular
 ```
 
 This will install `jest`, `@types/jest`, `ts-jest`, `jest-zone-patch` as dependencies needed to run with Angular projects.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add -D jest jest-preset-angular @types/jest
 npm install -D jest jest-preset-angular @types/jest
 ```
 
-This will install `jest`, `@types/jest`, `ts-jest`, `jest-zone-patch` as dependencies needed to run with Angular projects.
+This will install `jest`, `@types/jest`, `ts-jest` as dependencies needed to run with Angular projects.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ _Note: This preset does not suport AngularJS (1.x). If you want to set up Jest w
 ## Installation
 
 ```bash
-yarn add -D jest jest-preset-angular
+yarn add -D jest jest-preset-angular @types/jest
 # or
-npm install -D jest jest-preset-angular
+npm install -D jest jest-preset-angular @types/jest
 ```
 
 This will install `jest`, `@types/jest`, `ts-jest`, `jest-zone-patch` as dependencies needed to run with Angular projects.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ _Note: feel free to copy the `jestGlobalMocks.ts` file from the example director
 }
 ```
 
+### Avoid karma conflicts
+By Angular CLI defaults you'll have a `src/test.ts` file which will be picked up by jest. To circumvent this you can either rename it to `src/karmaTest.ts` or hide it from jest by adding `<rootDir>/src/test.ts` to jest `testPathIgnorePatterns` option.
+
+
 ## Exposed [configuration](https://github.com/thymikee/jest-preset-angular/blob/master/jest-preset.js)
 
 ```js


### PR DESCRIPTION
* jest-zone-patch is embeded (#214) as a dependency and should not be mentioned as being installed at the same time as this package is not found in package.json, package-lock.json or yarn.lock - and can be presumed missing.
* @types/jest might not be installed so install it explicitly
* Specify how to avoid karma conflicts (ref #233)
  - Otherwise consumers might get `TypeError: Cannot read property 'prototype' of undefined` while jest processes new angular cli projects