### PR TITLE
feat: transform 'styles' only in decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
-InlineHtmlStripStylesTransformer.js
+InlineFilesTransformer.js
+StripStylesTransformer.js
+TransformUtils.js
 *.log
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog (master)
 
+* (**BREAKING**): Refine ast-transformer behavior: only transform `styles`-assignments inside @Component ([#261](https://github.com/thymikee/jest-preset-angular/pull/261)) and TypeScript v2.9 `createStringLiteral` is polyfilled if an older version is used ([#272](https://github.com/thymikee/jest-preset-angular/issues/272)).
+
+#### Migration Guide
+* If the `astTransformers` are referenced in a custom `jest` config, `[ 'jest-preset-angular/InlineFilesTransformer', 'jest-preset-angular/StripStylesTransformer']` have to be set instead.
+
 ### v7.1.0
 
 #### Features

--- a/__tests__/StripStylesTransformer.test.ts
+++ b/__tests__/StripStylesTransformer.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Code is inspired by
+ * https://github.com/kulshekhar/ts-jest/blob/25e1c63dd3797793b0f46fa52fdee580b46f66ae/src/transformers/hoist-jest.spec.ts
+ *
+ */
+
+import * as tsc from 'typescript';
+import * as transformer from '../StripStylesTransformer';
+
+const CODE_WITH_STYLES_AND_OTHER_ASSIGNMENTS = `
+  import { Component } from '@angular/core';
+
+  @SomeDecorator({
+    value: 'test',
+    styles: [
+      ':host { background-color: red }'
+    ],
+  })
+  @Component({
+    templateUrl: './page.html',
+    styleUrls: [
+      './fancy-styles.css',
+      './basic-styles.scss'
+    ],
+    styles: [
+      'body { display: none }',
+      'html { background-color: red }'
+    ],
+    unaffectedProperty: 'whatever'
+  })
+  export class AngularComponent {
+  }
+`;
+
+const CODE_WITH_ASSIGNMENT_OUTSIDE_DECORATOR = `
+  const assignmentsToNotBeTransformed = {
+    styles: [{
+      color: 'red'
+    }]
+  };
+`;
+
+const createFactory = () => {
+  return transformer.factory({ compilerModule: tsc } as any);
+};
+const transpile = (source: string) =>
+  tsc.transpileModule(source, { transformers: { before: [createFactory()] } });
+
+describe('inlining template and stripping styles', () => {
+  it('should not strip styleUrls assignment', () => {
+    const out = transpile(CODE_WITH_STYLES_AND_OTHER_ASSIGNMENTS);
+
+    expect(out.outputText).toMatchSnapshot();
+  });
+
+  it('should not transform styles outside decorator', () => {
+    const out = transpile(CODE_WITH_ASSIGNMENT_OUTSIDE_DECORATOR);
+
+    expect(out.outputText).toMatchSnapshot();
+  });
+});

--- a/__tests__/__snapshots__/InlineFilesTransformer.test.ts.snap
+++ b/__tests__/__snapshots__/InlineFilesTransformer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`inlining template and stripping styles should handle all decorator assignments in differently named decorators 1`] = `
+exports[`inlining template and stripping styleUrls should handle all decorator assignments in differently named decorators 1`] = `
 "\\"use strict\\";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -24,7 +24,7 @@ exports.AngularComponent = AngularComponent;
 "
 `;
 
-exports[`inlining template and stripping styles should handle all transformable decorator assignments 1`] = `
+exports[`inlining template and stripping styleUrls should handle all transformable decorator assignments 1`] = `
 "\\"use strict\\";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -44,7 +44,10 @@ var AngularComponent = /** @class */ (function () {
         core_1.Component({
             template: require('./page.html'),
             styleUrls: [],
-            styles: [],
+            styles: [
+                'body { display: none }',
+                'html { background-color: red }'
+            ],
             unaffectedProperty: 'whatever'
         }),
         SomeOtherDecorator({
@@ -57,7 +60,7 @@ exports.AngularComponent = AngularComponent;
 "
 `;
 
-exports[`inlining template and stripping styles should handle templateUrl in test file outside decorator 1`] = `
+exports[`inlining template and stripping styleUrls should handle templateUrl in test file outside decorator 1`] = `
 "\\"use strict\\";
 Object.defineProperty(exports, \\"__esModule\\", { value: true });
 var testing_1 = require(\\"@angular/core/testing\\");
@@ -85,7 +88,7 @@ describe('AComponent', function () {
 "
 `;
 
-exports[`inlining template and stripping styles should inline non-relative templateUrl assignment and make it relative 1`] = `
+exports[`inlining template and stripping styleUrls should inline non-relative templateUrl assignment and make it relative 1`] = `
 "\\"use strict\\";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -109,7 +112,7 @@ exports.AngularComponent = AngularComponent;
 "
 `;
 
-exports[`inlining template and stripping styles should inline templateUrl assignment 1`] = `
+exports[`inlining template and stripping styleUrls should inline templateUrl assignment 1`] = `
 "\\"use strict\\";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -133,7 +136,47 @@ exports.AngularComponent = AngularComponent;
 "
 `;
 
-exports[`inlining template and stripping styles should strip styleUrl assignment 1`] = `
+exports[`inlining template and stripping styleUrls should not strip styles assignment 1`] = `
+"\\"use strict\\";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+var core_1 = require(\\"@angular/core\\");
+var AngularComponent = /** @class */ (function () {
+    function AngularComponent() {
+    }
+    AngularComponent = __decorate([
+        core_1.Component({
+            styles: [
+                'body { display: none }',
+                'html { background-color: red }'
+            ]
+        })
+    ], AngularComponent);
+    return AngularComponent;
+}());
+exports.AngularComponent = AngularComponent;
+"
+`;
+
+exports[`inlining template and stripping styleUrls should not transform styles outside decorator 1`] = `
+"var assignmentsToNotBeTransformed = {
+    styles: [{
+            color: 'red'
+        }]
+};
+var assignmentsToBeTransformed = {
+    styleUrls: [],
+    template: require('./some-styles.css')
+};
+"
+`;
+
+exports[`inlining template and stripping styleUrls should strip styleUrls assignment 1`] = `
 "\\"use strict\\";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -149,30 +192,6 @@ var AngularComponent = /** @class */ (function () {
     AngularComponent = __decorate([
         core_1.Component({
             styleUrls: []
-        })
-    ], AngularComponent);
-    return AngularComponent;
-}());
-exports.AngularComponent = AngularComponent;
-"
-`;
-
-exports[`inlining template and stripping styles should strip styles assignment 1`] = `
-"\\"use strict\\";
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-Object.defineProperty(exports, \\"__esModule\\", { value: true });
-var core_1 = require(\\"@angular/core\\");
-var AngularComponent = /** @class */ (function () {
-    function AngularComponent() {
-    }
-    AngularComponent = __decorate([
-        core_1.Component({
-            styles: []
         })
     ], AngularComponent);
     return AngularComponent;

--- a/__tests__/__snapshots__/StripStylesTransformer.test.ts.snap
+++ b/__tests__/__snapshots__/StripStylesTransformer.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inlining template and stripping styles should not transform styles outside decorator 1`] = `
+"var assignmentsToNotBeTransformed = {
+    styles: [{
+            color: 'red'
+        }]
+};
+"
+`;
+
+exports[`inlining template and stripping styles should not strip styleUrls assignment 1`] = `
+"\\"use strict\\";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === \\"object\\" && typeof Reflect.decorate === \\"function\\") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+var core_1 = require(\\"@angular/core\\");
+var AngularComponent = /** @class */ (function () {
+    function AngularComponent() {
+    }
+    AngularComponent = __decorate([
+        SomeDecorator({
+            value: 'test',
+            styles: [
+                ':host { background-color: red }'
+            ],
+        }),
+        core_1.Component({
+            templateUrl: './page.html',
+            styleUrls: [
+                './fancy-styles.css',
+                './basic-styles.scss'
+            ],
+            styles: [],
+            unaffectedProperty: 'whatever'
+        })
+    ], AngularComponent);
+    return AngularComponent;
+}());
+exports.AngularComponent = AngularComponent;
+"
+`;

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -3,7 +3,10 @@ module.exports = {
     'ts-jest': {
       tsConfig: '<rootDir>/src/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.html$',
-      astTransformers: [require.resolve('./InlineHtmlStripStylesTransformer')],
+      astTransformers: [
+        require.resolve('./InlineFilesTransformer'),
+        require.resolve('./StripStylesTransformer'),
+      ],
     },
   },
   transform: {

--- a/src/StripStylesTransformer.ts
+++ b/src/StripStylesTransformer.ts
@@ -1,0 +1,148 @@
+/*
+ * Code is inspired by
+ * https://github.com/kulshekhar/ts-jest/blob/25e1c63dd3797793b0f46fa52fdee580b46f66ae/src/transformers/hoist-jest.ts
+ *
+ * 
+ * IMPLEMENTATION DETAILS:
+ * This transformer handles one concern: removing styles.
+ *
+ * The property 'styles' inside a @Component(...) Decorator argument will
+ * be modified, even if they are not used in the context of an
+ * Angular Component.
+ * 
+ * This is the required AST to trigger the transformation:
+ * 
+ * ClassDeclaration
+ *   Decorator
+ *     CallExpression
+ *       ObjectLiteralExpression
+ *         PropertyAssignment
+ *           Identifier
+ *           StringLiteral
+ */
+
+// only import types, for the rest use injected `ConfigSet.compilerModule`
+import {
+  Node,
+  SourceFile,
+  TransformationContext,
+  Transformer,
+  Visitor,
+  Identifier,
+  ClassDeclaration,
+  PropertyAssignment
+} from 'typescript';
+import { ConfigSet } from './TransformUtils';
+
+/** Angular component decorator Styles property name */
+const STYLES = 'styles';
+/** Angular component decorator name */
+const COMPONENT = 'Component';
+/** All props to be transformed inside a decorator */
+const TRANSFORM_IN_DECORATOR_PROPS = [STYLES];
+
+/**
+ * Transformer ID
+ * @internal
+ */
+export const name = 'angular-component-strip-styles';
+
+// increment this each time the code is modified
+/**
+ * Transformer Version
+ * @internal
+ */
+export const version = 1;
+
+/**
+ * The factory of hoisting transformer factory
+ * @internal
+ */
+export function factory(cs: ConfigSet) {
+  /**
+   * Our compiler (typescript, or a module with typescript-like interface)
+   */
+  const ts = cs.compilerModule;
+
+  /**
+   * Traverses the AST down inside a decorator to a styles assignment
+   * and returns a boolean indicating if it should be transformed.
+   */
+  function isInDecoratorPropertyAssignmentToTransform(node: Node): node is ClassDeclaration {
+    return getInDecoratorPropertyAssignmentsToTransform(node).length > 0;
+  }
+
+  /**
+   * Traverses the AST down inside a decorator to a styles assignment
+   * returns it in an array.
+   */
+  function getInDecoratorPropertyAssignmentsToTransform(node: Node) {
+    if (!ts.isClassDeclaration(node) || !node.decorators) {
+      return [];
+    }
+
+    return node.decorators
+      .map(dec => dec.expression)
+      .filter(ts.isCallExpression)
+      .filter(callExpr => ts.isCallExpression(callExpr) && ts.isIdentifier(callExpr.expression) && callExpr.expression.getText() === COMPONENT)
+      .reduce((acc, nxtCallExpr) => Array.prototype.concat.apply(acc, 
+        nxtCallExpr.arguments
+          .filter(ts.isObjectLiteralExpression)
+          .reduce((acc, nxtArg) => Array.prototype.concat.apply(acc,
+            nxtArg.properties
+              .filter(ts.isPropertyAssignment)
+              .filter(propAss =>
+                ts.isIdentifier(propAss.name) &&
+                TRANSFORM_IN_DECORATOR_PROPS.includes(
+                  (propAss.name as Identifier).text
+                )
+              )
+          ), [] as PropertyAssignment[])
+      ), [] as PropertyAssignment[])
+  }
+
+  /**
+   * Clones the styles assignment and manipulates it.
+   * @param node the property assignment to change
+   */
+  function transfromStylesAssignmentForJest(node: ClassDeclaration) {
+    const mutableNode = ts.getMutableClone(node)
+    const assignments = getInDecoratorPropertyAssignmentsToTransform(mutableNode)
+
+    assignments.forEach(assignment => {
+      if ((assignment.name as Identifier).text === STYLES) {
+        // replace initializer array with empty array
+        assignment.initializer = ts.createArrayLiteral()
+      }
+    })
+    return mutableNode
+  }
+
+  /**
+   * Create a source file visitor which will visit all nodes in a source file
+   * @param ctx The typescript transformation context
+   * @param _ The owning source file
+   */
+  function createVisitor(ctx: TransformationContext, _: SourceFile) {
+    /**
+     * Main visitor, which will be called recursively for each node in the source file's AST
+     * @param node The node to be visited
+     */
+    const visitor: Visitor = node => {
+      // before we create a deep clone to modify, we make sure that
+      // this is an assignment which we want to transform
+      if (isInDecoratorPropertyAssignmentToTransform(node)) {
+        // get transformed node with changed properties
+        return transfromStylesAssignmentForJest(node);
+      } else {
+        // else look for assignments inside this node recursively
+        return ts.visitEachChild(node, visitor, ctx);
+      }
+    };
+    return visitor;
+  }
+
+  return (ctx: TransformationContext): Transformer<SourceFile> => (
+    sf: SourceFile
+  ) => ts.visitNode(sf, createVisitor(ctx, sf));
+}

--- a/src/TransformUtils.ts
+++ b/src/TransformUtils.ts
@@ -1,0 +1,30 @@
+import TS from 'typescript';
+
+// replace original ts-jest ConfigSet with this simple interface, as it would require
+// jest-preset-angular to add several babel devDependencies to get the other types
+// inside the ConfigSet right
+export interface ConfigSet {
+  compilerModule: typeof TS;
+}
+
+/**
+ * returns the compiler function to create a string literal. If an old version
+ * of the TypeScript module is used, it will create a function that replaces the
+ * behavior of the `createStringLiteral` function.
+ * @param ts TypeScript compiler module
+ */
+export function getCreateStringLiteral(
+  ts: typeof TS
+): typeof TS.createStringLiteral {
+  if (ts.createStringLiteral && typeof ts.createStringLiteral === 'function') {
+    return ts.createStringLiteral;
+  }
+  return function createStringLiteral(text: string) {
+    const node = <TS.StringLiteral>(
+      ts.createNode(ts.SyntaxKind.StringLiteral, -1, -1)
+    );
+    node.text = text;
+    node.flags |= ts.NodeFlags.Synthesized;
+    return node;
+  };
+}


### PR DESCRIPTION
This PR is another implementation change in the transformation behavior. It is a proposal and open for discussion.

### Motivation

See #254 

Until now we transformed 'templateUrl', 'styleUrls' and 'styles'
everywhere they were assigned.

This even transformed code like this:
`console.log({ styles: {...}})` => `console.log({ styles: [] })`

The new implementation of the AstTransformer only transforms property
assignments to 'styles' if it is placed inside a decorator.

`templateUrl` and `styleUrls` are still transformed everywhere if assigned to a string, as Angular might expect them to be an actual Angular-Template or CSS code. This will crash the tests, if they are passed to the `@Component` decorator.

### Example
A new unit test explains the new implementation:

Untransformed:
```ts
  const assignmentsToNotBeTransformed = {
    styles: [{
      color: 'red'
    }]
  };

  const assignmentsToBeTransformed = {
    styleUrls: ['./some-styles.css'],
    templateUrl: './some-styles.css'
  };
```
Transformed:
```js
var assignmentsToNotBeTransformed = {
    styles: [{
            color: 'red'
        }]
};
var assignmentsToBeTransformed = {
    styleUrls: [],
    template: require('./some-styles.css')
};
```

### Caveats
There were always caveats and there still will be.
* This preset replaces styles wherever it decides they are not required. This design-decision was made due to the unit-test nature of jest. To test your styles, better use an e2e framework. The style stripping should speed up your tests, but might hinder you from testing applied styles.
* `templateUrl` and `styleUrls` are transformed anywhere in the code. This enables you to declare them somewhere in your unit tests and then plug them into a component, e. g. using  
  ```js
    TestBed.configureTestingModule({
      declarations: [
        AlertFollowComponent,
      ],
    }).overrideComponent(AlertFollowComponent, {
      set: {
        templateUrl: '../__mocks__/alert-follow-stub.component.html',
      },
    });
  ```
  At the same time, there will be side-effects on variables named `templateUrl` and `styleUrls` if you use them in a different context.

**EDIT**:
* The implementation lead to introduce more code in the ASTTransformer, this means, while it is more granular in its behavior, it is also more difficult to maintain.

Closes #254 