### PR TITLE
docs: add a warning message for exposed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ By Angular CLI defaults you'll have a `src/test.ts` file which will be picked up
 
 
 ## Exposed [configuration](https://github.com/thymikee/jest-preset-angular/blob/master/jest-preset.js)
+> :warning: This is the latest configuration file from the master branch. If you are using the latest NPM package, please follow [this link](https://www.npmjs.com/package/jest-preset-angular#exposed-configuration) for the exposed configuration.
 
 ```js
 module.exports = {


### PR DESCRIPTION
Closes #312

The message can be hidden on npm by using templates, or a quick `prepublish` script that runs an `sed` command (or equivalent) so it shows up on Github only.