### PR TITLE
Improve coverage defaults of preset

### DIFF
--- a/example/jest.config.js
+++ b/example/jest.config.js
@@ -11,5 +11,10 @@ module.exports = {
   },
   setupFilesAfterEnv: [
     "<rootDir>/src/setupJest.ts"
+  ],
+  collectCoverageFrom: [
+    "<rootDir>/src/app/**/*.ts",
+    "!<rootDir>/src/app/**/*.module.ts",
+    "!<rootDir>/src/app/**/test/*"
   ]
 }

--- a/example/jest.config.js
+++ b/example/jest.config.js
@@ -14,7 +14,6 @@ module.exports = {
   ],
   collectCoverageFrom: [
     "<rootDir>/src/app/**/*.ts",
-    "!<rootDir>/src/app/**/*.module.ts",
-    "!<rootDir>/src/app/**/test/*"
+    "!<rootDir>/src/app/**/*.module.ts"
   ]
 }


### PR DESCRIPTION
By default only files that are actually used in tests are included in the coverage report. This change ensures that files have no tests (0% coverage) are included in the report.