### PR TITLE
fix: test.each should be in ProxyZone

### DIFF
--- a/example/src/app/app.component.spec.ts
+++ b/example/src/app/app.component.spec.ts
@@ -1,10 +1,5 @@
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import {
-  async,
-  fakeAsync,
-  tick,
-  ComponentFixture,
-} from '@angular/core/testing';
+import { async, fakeAsync, tick, ComponentFixture } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { ConfigureFn, configureTests } from '@lib/testing';
@@ -20,7 +15,7 @@ describe('AppComponent', () => {
       testBed.configureTestingModule({
         declarations: [AppComponent],
         imports: [NoopAnimationsModule],
-        schemas: [NO_ERRORS_SCHEMA],
+        schemas: [NO_ERRORS_SCHEMA]
       });
     };
 
@@ -50,8 +45,9 @@ describe('AppComponent', () => {
     expect(compiled.querySelector('h1').textContent).toContain('app works!');
   }));
 
-  it('looks async but is synchronous', <any>fakeAsync(
-    (): void => {
+  it(
+    'looks async but is synchronous',
+    <any>fakeAsync((): void => {
       let flag = false;
       setTimeout(() => {
         flag = true;
@@ -61,8 +57,28 @@ describe('AppComponent', () => {
       expect(flag).toBe(false);
       tick(50);
       expect(flag).toBe(true);
-    }
-  ));
+    })
+  );
+
+  it(
+    'async should work',
+    <any>async((): void => {
+      let flag = false;
+      setTimeout(() => {
+        flag = true;
+        expect(flag).toBe(true);
+      }, 100);
+    })
+  );
+
+  it('test with done should work', (done): void => {
+    let flag = false;
+    setTimeout(() => {
+      flag = true;
+      expect(flag).toBe(true);
+      done();
+    }, 100);
+  });
 });
 
 test.todo('a sample todo');

--- a/example/src/app/service/hero.service.spec.ts
+++ b/example/src/app/service/hero.service.spec.ts
@@ -1,104 +1,135 @@
-import { inject, TestBed } from '@angular/core/testing'
-import { HttpClientModule, HttpErrorResponse, HttpRequest } from '@angular/common/http'
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import {
+  HttpClientModule,
+  HttpErrorResponse,
+  HttpRequest
+} from "@angular/common/http";
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from "@angular/common/http/testing";
+import { inject, TestBed } from "@angular/core/testing";
 
-import { heroesUrl, HeroService } from './hero.service'
+import { heroesUrl, HeroService } from "./hero.service";
 
-describe('Service: HeroService', () => {
-  let service: HeroService
-  let backend: HttpTestingController
+describe("Service: HeroService", () => {
+  let service: HeroService;
+  let backend: HttpTestingController;
 
-  const expectedData = {
-    id: 1,
-    name: 'Test hero',
-  }
+  const expectedData = { id: 1, name: "Test hero" };
 
   const expectedDataAll = [
-    {
-      id: 1,
-      name: 'Test hero 1'
-    },
-    {
-      id: 2,
-      name: 'Test hero 2'
-    }
-  ]
+    { id: 1, name: "Test hero 1" },
+    { id: 2, name: "Test hero 2" }
+  ];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientModule,
-        HttpClientTestingModule,
-      ],
-      providers: [
-        HeroService,
-      ],
-    })
+      imports: [HttpClientModule, HttpClientTestingModule],
+      providers: [HeroService]
+    });
 
-    backend = TestBed.get(HttpTestingController)
-    service = TestBed.get(HeroService)
+    backend = TestBed.get(HttpTestingController);
+    service = TestBed.get(HeroService);
 
     // Mock implementation of console.error to
     // return undefined to stop printing out to console log during test
-    jest.spyOn(console, 'error').mockImplementation(() => undefined)
-  })
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
 
-  afterEach(inject([ HttpTestingController ], (_backend: HttpTestingController) => {
-    _backend.verify()
-  }))
+  afterEach(inject(
+    [HttpTestingController],
+    (_backend: HttpTestingController) => {
+      _backend.verify();
+    }
+  ));
 
-  it('should create an instance successfully', () => {
-    expect(service).toBeDefined()
-  })
+  it("should create an instance successfully", () => {
+    expect(service).toBeDefined();
+  });
 
-  it('should call the GET heroes api and return all results', () => {
-    let actualDataAll = {}
+  it("should call the GET heroes api and return all results", () => {
+    let actualDataAll = {};
 
-    service.getHeroes().subscribe(data => actualDataAll = data)
+    service.getHeroes().subscribe(data => (actualDataAll = data));
 
-    backend.expectOne((req: HttpRequest<any>) => {
-      return req.url === `${heroesUrl}`
-        && req.method === 'GET'
-    }, `GET all hero data from ${heroesUrl}`)
-      .flush(expectedDataAll)
+    backend
+      .expectOne((req: HttpRequest<any>) => {
+        return req.url === `${heroesUrl}` && req.method === "GET";
+      }, `GET all hero data from ${heroesUrl}`)
+      .flush(expectedDataAll);
 
-    expect(actualDataAll).toEqual(expectedDataAll)
-  })
+    expect(actualDataAll).toEqual(expectedDataAll);
+  });
 
-  it('should call the GET hero api and return the result', () => {
-    let actualData = {}
+  it("should call the GET hero api with id and return the result", () => {
+    let actualData = {};
 
-    service.getHero(1).subscribe(data => actualData = data)
+    service.getHero(1).subscribe(data => (actualData = data));
 
-    backend.expectOne((req: HttpRequest<any>) => {
-      return req.url === `${heroesUrl}`
-        && req.method === 'GET'
-        && req.params.get('id') === '1'
-    }, `GET hero data from ${heroesUrl}?id=1`)
-      .flush(expectedData)
+    backend
+      .expectOne((req: HttpRequest<any>) => {
+        return (
+          req.url === `${heroesUrl}` &&
+          req.method === "GET" &&
+          req.params.get("id") === "1"
+        );
+      }, `GET hero data from ${heroesUrl}?id=1`)
+      .flush(expectedData);
 
-    expect(actualData).toEqual(expectedData)
-  })
+    expect(actualData).toEqual(expectedData);
+  });
 
-  it('should send an expected GET request and throw error to console when an error occurs', () => {
-    service.getHero(1).subscribe()
+  test.each([
+    [1, { id: 1, name: "Test Hero 1" }],
+    [2, { id: 2, name: "Test Hero 2" }]
+  ])(
+    "should call the GET hero api and return the result",
+    (id: number, testData: any) => {
+      debugger;
+      console.log(
+        "id, testData",
+        id,
+        testData,
+        (window as any).Zone.current.name
+      );
+      let actualData = {};
+
+      service.getHero(1).subscribe(data => (actualData = data));
+
+      backend
+        .expectOne((req: HttpRequest<any>) => {
+          return req.url === `${heroesUrl}` && req.method === "GET";
+        }, `GET hero data from ${heroesUrl}?id=${id}`)
+        .flush(testData);
+
+      expect(actualData).toEqual(testData);
+    }
+  );
+
+  it("should send an expected GET request and throw error to console when an error occurs", () => {
+    service.getHero(1).subscribe();
 
     const getHeroRequest = backend.expectOne((req: HttpRequest<any>) => {
-      return req.url === `${heroesUrl}`
-        && req.method === 'GET'
-        && req.params.get('id') === '1'
-    }, `GET hero data from ${heroesUrl}?id=1`)
+      return (
+        req.url === `${heroesUrl}` &&
+        req.method === "GET" &&
+        req.params.get("id") === "1"
+      );
+    }, `GET hero data from ${heroesUrl}?id=1`);
 
     // Stimulate an error happens from the backend
-    getHeroRequest.error(new ErrorEvent('ERROR_GET_HERO_DATA'))
+    getHeroRequest.error(new ErrorEvent("ERROR_GET_HERO_DATA"));
 
-    expect(console.error).toHaveBeenCalled()
-  })
+    expect(console.error).toHaveBeenCalled();
+  });
 
-  it('should return an observable of undefined and print error to console', () => {
-    const result = service.handleError(new HttpErrorResponse({ error: 'Error occurs' }), 'test method')
+  it("should return an observable of undefined and print error to console", () => {
+    const result = service.handleError(
+      new HttpErrorResponse({ error: "Error occurs" }),
+      "test method"
+    );
 
-    expect(console.error).toHaveBeenCalled()
-    result.subscribe(value => expect(value).toBeUndefined())
-  })
-})
+    expect(console.error).toHaveBeenCalled();
+    result.subscribe(value => expect(value).toBeUndefined());
+  });
+});

--- a/example/src/app/service/hero.service.spec.ts
+++ b/example/src/app/service/hero.service.spec.ts
@@ -69,8 +69,6 @@ describe('Service: HeroService', () => {
     [1, { id: 1, name: 'Test Hero 1' }],
     [2, { id: 2, name: 'Test Hero 2' }]
   ])('should call the GET hero api and return the result', (id: number, testData: any) => {
-    debugger;
-    console.log('id, testData', id, testData, (window as any).Zone.current.name);
     let actualData = {};
 
     service.getHero(1).subscribe(data => (actualData = data));

--- a/example/src/app/service/hero.service.spec.ts
+++ b/example/src/app/service/hero.service.spec.ts
@@ -1,25 +1,18 @@
-import {
-  HttpClientModule,
-  HttpErrorResponse,
-  HttpRequest
-} from "@angular/common/http";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
-import { inject, TestBed } from "@angular/core/testing";
+import { HttpClientModule, HttpErrorResponse, HttpRequest } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
 
-import { heroesUrl, HeroService } from "./hero.service";
+import { heroesUrl, HeroService } from './hero.service';
 
-describe("Service: HeroService", () => {
+describe('Service: HeroService', () => {
   let service: HeroService;
   let backend: HttpTestingController;
 
-  const expectedData = { id: 1, name: "Test hero" };
+  const expectedData = { id: 1, name: 'Test hero' };
 
   const expectedDataAll = [
-    { id: 1, name: "Test hero 1" },
-    { id: 2, name: "Test hero 2" }
+    { id: 1, name: 'Test hero 1' },
+    { id: 2, name: 'Test hero 2' }
   ];
 
   beforeEach(() => {
@@ -33,46 +26,39 @@ describe("Service: HeroService", () => {
 
     // Mock implementation of console.error to
     // return undefined to stop printing out to console log during test
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
-  afterEach(inject(
-    [HttpTestingController],
-    (_backend: HttpTestingController) => {
-      _backend.verify();
-    }
-  ));
+  afterEach(inject([HttpTestingController], (_backend: HttpTestingController) => {
+    _backend.verify();
+  }));
 
-  it("should create an instance successfully", () => {
+  it('should create an instance successfully', () => {
     expect(service).toBeDefined();
   });
 
-  it("should call the GET heroes api and return all results", () => {
+  it('should call the GET heroes api and return all results', () => {
     let actualDataAll = {};
 
     service.getHeroes().subscribe(data => (actualDataAll = data));
 
     backend
       .expectOne((req: HttpRequest<any>) => {
-        return req.url === `${heroesUrl}` && req.method === "GET";
+        return req.url === `${heroesUrl}` && req.method === 'GET';
       }, `GET all hero data from ${heroesUrl}`)
       .flush(expectedDataAll);
 
     expect(actualDataAll).toEqual(expectedDataAll);
   });
 
-  it("should call the GET hero api with id and return the result", () => {
+  it('should call the GET hero api with id and return the result', () => {
     let actualData = {};
 
     service.getHero(1).subscribe(data => (actualData = data));
 
     backend
       .expectOne((req: HttpRequest<any>) => {
-        return (
-          req.url === `${heroesUrl}` &&
-          req.method === "GET" &&
-          req.params.get("id") === "1"
-        );
+        return req.url === `${heroesUrl}` && req.method === 'GET' && req.params.get('id') === '1';
       }, `GET hero data from ${heroesUrl}?id=1`)
       .flush(expectedData);
 
@@ -80,53 +66,41 @@ describe("Service: HeroService", () => {
   });
 
   test.each([
-    [1, { id: 1, name: "Test Hero 1" }],
-    [2, { id: 2, name: "Test Hero 2" }]
-  ])(
-    "should call the GET hero api and return the result",
-    (id: number, testData: any) => {
-      debugger;
-      console.log(
-        "id, testData",
-        id,
-        testData,
-        (window as any).Zone.current.name
-      );
-      let actualData = {};
+    [1, { id: 1, name: 'Test Hero 1' }],
+    [2, { id: 2, name: 'Test Hero 2' }]
+  ])('should call the GET hero api and return the result', (id: number, testData: any) => {
+    debugger;
+    console.log('id, testData', id, testData, (window as any).Zone.current.name);
+    let actualData = {};
 
-      service.getHero(1).subscribe(data => (actualData = data));
+    service.getHero(1).subscribe(data => (actualData = data));
 
-      backend
-        .expectOne((req: HttpRequest<any>) => {
-          return req.url === `${heroesUrl}` && req.method === "GET";
-        }, `GET hero data from ${heroesUrl}?id=${id}`)
-        .flush(testData);
+    backend
+      .expectOne((req: HttpRequest<any>) => {
+        return req.url === `${heroesUrl}` && req.method === 'GET';
+      }, `GET hero data from ${heroesUrl}?id=${id}`)
+      .flush(testData);
 
-      expect(actualData).toEqual(testData);
-    }
-  );
+    expect(actualData).toEqual(testData);
+  });
 
-  it("should send an expected GET request and throw error to console when an error occurs", () => {
+  it('should send an expected GET request and throw error to console when an error occurs', () => {
     service.getHero(1).subscribe();
 
     const getHeroRequest = backend.expectOne((req: HttpRequest<any>) => {
-      return (
-        req.url === `${heroesUrl}` &&
-        req.method === "GET" &&
-        req.params.get("id") === "1"
-      );
+      return req.url === `${heroesUrl}` && req.method === 'GET' && req.params.get('id') === '1';
     }, `GET hero data from ${heroesUrl}?id=1`);
 
     // Stimulate an error happens from the backend
-    getHeroRequest.error(new ErrorEvent("ERROR_GET_HERO_DATA"));
+    getHeroRequest.error(new ErrorEvent('ERROR_GET_HERO_DATA'));
 
     expect(console.error).toHaveBeenCalled();
   });
 
-  it("should return an observable of undefined and print error to console", () => {
+  it('should return an observable of undefined and print error to console', () => {
     const result = service.handleError(
-      new HttpErrorResponse({ error: "Error occurs" }),
-      "test method"
+      new HttpErrorResponse({ error: 'Error occurs' }),
+      'test method'
     );
 
     expect(console.error).toHaveBeenCalled();

--- a/example/src/app/simple/another.component.ts
+++ b/example/src/app/simple/another.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'another-comp',
+  template: ''
+})
+export class AnotherComponent {}

--- a/example/src/app/simple/simple.component.spec.ts
+++ b/example/src/app/simple/simple.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture } from '@angular/core/testing';
 import { ConfigureFn, configureTests } from '@lib/testing';
 
 import { SimpleComponent } from './simple.component';
-import { Component } from '@angular/core';
+import { AnotherComponent } from './another.component';
 
 describe('SimpleComponent', () => {
   let component: SimpleComponent;
@@ -35,12 +35,6 @@ describe('SimpleComponent', () => {
     expect(fixture.nativeElement).toMatchSnapshot();
   });
 });
-
-@Component({
-  selector: 'another-comp',
-  template: ''
-})
-class AnotherComponent {}
 
 describe.each([[SimpleComponent, AnotherComponent]])('Test components', ComponentType => {
   let component: any;

--- a/example/src/app/simple/simple.component.spec.ts
+++ b/example/src/app/simple/simple.component.spec.ts
@@ -1,28 +1,27 @@
 import { async, ComponentFixture } from '@angular/core/testing';
 
-import {ConfigureFn, configureTests} from '@lib/testing';
+import { ConfigureFn, configureTests } from '@lib/testing';
 
 import { SimpleComponent } from './simple.component';
+import { Component } from '@angular/core';
 
 describe('SimpleComponent', () => {
   let component: SimpleComponent;
   let fixture: ComponentFixture<SimpleComponent>;
 
-  beforeEach(
-    async(() => {
-      const configure: ConfigureFn = testBed => {
-        testBed.configureTestingModule({
-          declarations: [ SimpleComponent ]
-        });
-      };
-
-      configureTests(configure).then(testBed => {
-        fixture = testBed.createComponent(SimpleComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
+  beforeEach(async(() => {
+    const configure: ConfigureFn = testBed => {
+      testBed.configureTestingModule({
+        declarations: [SimpleComponent]
       });
-    })
-  );
+    };
+
+    configureTests(configure).then(testBed => {
+      fixture = testBed.createComponent(SimpleComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
@@ -34,5 +33,34 @@ describe('SimpleComponent', () => {
 
   it('snapshot on nativeElement should be without ng-version', () => {
     expect(fixture.nativeElement).toMatchSnapshot();
+  });
+});
+
+@Component({
+  selector: 'another-comp',
+  template: ''
+})
+class AnotherComponent {}
+
+describe.each([[SimpleComponent, AnotherComponent]])('Test components', ComponentType => {
+  let component: any;
+  let fixture: ComponentFixture<any>;
+
+  beforeEach(async(() => {
+    const configure: ConfigureFn = testBed => {
+      testBed.configureTestingModule({
+        declarations: [ComponentType]
+      });
+    };
+
+    configureTests(configure).then(testBed => {
+      fixture = testBed.createComponent(ComponentType);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
   });
 });

--- a/src/zone-patch/index.js
+++ b/src/zone-patch/index.js
@@ -48,9 +48,9 @@ function wrapTestInZone(testBody) {
   if (testBody === undefined) {
     return;
   }
-  return testBody.length === 0
-    ? () => testProxyZone.run(testBody, null)
-    : done => testProxyZone.run(testBody, null, [done]);
+  return function() {
+    return testProxyZone.run(testBody, null, arguments);
+  };
 }
 
 const bindDescribe = originalJestFn =>

--- a/src/zone-patch/index.js
+++ b/src/zone-patch/index.js
@@ -36,8 +36,8 @@ const ambientZone = Zone.current;
 // inside of a `describe` but outside of a `beforeEach` or `it`.
 const syncZone = ambientZone.fork(new SyncTestZoneSpec('jest.describe'));
 function wrapDescribeInZone(describeBody) {
-  return function() {
-    return syncZone.run(describeBody, null, arguments);
+  return function(...args) {
+    return syncZone.run(describeBody, null, args);
   };
 }
 
@@ -48,34 +48,38 @@ function wrapTestInZone(testBody) {
   if (testBody === undefined) {
     return;
   }
-  return function() {
-    return testProxyZone.run(testBody, null, arguments);
+  return function(...args) {
+    return testProxyZone.run(testBody, null, args);
   };
 }
 
+/**
+ * bind describe method to wrap describe.each function
+ */
 const bindDescribe = originalJestFn =>
-  function() {
-    const eachArguments = arguments;
-    return function(description, specDefinitions, timeout) {
-      arguments[1] = wrapDescribeInZone(specDefinitions);
-      return originalJestFn.apply(this, eachArguments).apply(this, arguments);
+  function(...eachArgs) {
+    return function(...args) {
+      args[1] = wrapDescribeInZone(args[1]);
+      return originalJestFn.apply(this, eachArgs).apply(this, args);
     };
   };
 
+/**
+ * bind test method to wrap test.each function
+ */
 const bindTest = originalJestFn =>
-  function() {
-    const eachArguments = arguments;
-    return function(description, specDefinitions, timeout) {
-      arguments[1] = wrapTestInZone(specDefinitions);
-      return originalJestFn.apply(this, eachArguments).apply(this, arguments);
+  function(...eachArgs) {
+    return function(...args) {
+      args[1] = wrapTestInZone(args[1]);
+      return originalJestFn.apply(this, eachArgs).apply(this, args);
     };
   };
 
 ['xdescribe', 'fdescribe', 'describe'].forEach(methodName => {
   const originaljestFn = env[methodName];
-  env[methodName] = function(description, specDefinitions, timeout) {
-    arguments[1] = wrapDescribeInZone(specDefinitions);
-    return originaljestFn.apply(this, arguments);
+  env[methodName] = function(...args) {
+    args[1] = wrapDescribeInZone(args[1]);
+    return originaljestFn.apply(this, args);
   };
   env[methodName].each = bindDescribe(originaljestFn.each);
   if (methodName === 'describe') {
@@ -86,9 +90,9 @@ const bindTest = originalJestFn =>
 
 ['xit', 'fit', 'xtest', 'test', 'it'].forEach(methodName => {
   const originaljestFn = env[methodName];
-  env[methodName] = function(description, specDefinitions, timeout) {
-    arguments[1] = wrapTestInZone(specDefinitions);
-    return originaljestFn.apply(this, arguments);
+  env[methodName] = function(...args) {
+    args[1] = wrapTestInZone(args[1]);
+    return originaljestFn.apply(this, args);
   };
   env[methodName].each = bindTest(originaljestFn.each);
 
@@ -96,16 +100,16 @@ const bindTest = originalJestFn =>
     env[methodName].only = env['fit'];
     env[methodName].skip = env['xit'];
 
-    env[methodName].todo = function() {
-      return originaljestFn.todo.apply(this, arguments);
+    env[methodName].todo = function(...args) {
+      return originaljestFn.todo.apply(this, args);
     };
   }
 });
 
 ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach(methodName => {
   const originaljestFn = env[methodName];
-  env[methodName] = function(specDefinitions, timeout) {
-    arguments[0] = wrapTestInZone(specDefinitions);
-    return originaljestFn.apply(this, arguments);
+  env[methodName] = function(...args) {
+    args[0] = wrapTestInZone(args[0]);
+    return originaljestFn.apply(this, args);
   };
 });


### PR DESCRIPTION
Close #339.

Fix `test.each` not in ProxyZone issue.
Also remove some not needed assignment.

And I will try to move this source into `angular/zone.js` repo, and also add support to timer methods such as `jest.fakeTimers/jest.runAllTicks`, after that `jest-preset-angular` can just import `zone-testing` bundle.

@thymikee , please help to check this one, thank you!