### PR TITLE
emitDecoratorMetadata Documentation for issue 288

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Problems may arise if you're using custom builds (this preset is tailored for `a
 
 ### Can't resolve all parameters for SomeClass(?)
 
-For Angular 8 users, a [change to the way the Angular CLI works](https://github.com/thymikee/jest-preset-angular/issues/288) may be causing your metadata to be lost.  You can update your `tsconfig.spec.json` to include the `emitDecoratorMetadata` compiler option:
+With Angular 8 and higher, a [change to the way the Angular CLI works](https://github.com/thymikee/jest-preset-angular/issues/288) may be causing your metadata to be lost.  You can update your `tsconfig.spec.json` to include the `emitDecoratorMetadata` compiler option:
 
 ```
   "compilerOptions": {

--- a/README.md
+++ b/README.md
@@ -236,10 +236,9 @@ Problems may arise if you're using custom builds (this preset is tailored for `a
 
 For Angular 8 users, a [change to the way the Angular CLI works](https://github.com/thymikee/jest-preset-angular/issues/288) may be causing your metadata to be lost.  You can update your `tsconfig.spec.json` to include the `emitDecoratorMetadata` compiler option:
 
-```json
-{
+```
   "compilerOptions": {
-    "emitDecoratorMetadata": true,
+    "emitDecoratorMetadata": true
 ```
 
 In general, this is related to Angular's reflection and also depends on a reflection library, as e. g. included in `core-js`. We use our own minimal reflection that satisfy Angular's current requirements, but in case these change, you can install `core-js` and import the reflection library in your `setupJest.ts`:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,15 @@ Problems may arise if you're using custom builds (this preset is tailored for `a
 
 ### Can't resolve all parameters for SomeClass(?)
 
-This is related to Angular's reflection and also depends on a reflection library, as e. g. included in `core-js`. We use our own minimal reflection that satisfy Angular's current requirements, but in case these change, you can install `core-js` and import the reflection library in your `setupJest.ts`:
+For Angular 8 users, a [change to the way the Angular CLI works](https://github.com/thymikee/jest-preset-angular/issues/288) may be causing your metadata to be lost.  You can update your `tsconfig.spec.json` to include the `emitDecoratorMetadata` compiler option:
+
+```json
+{
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+```
+
+In general, this is related to Angular's reflection and also depends on a reflection library, as e. g. included in `core-js`. We use our own minimal reflection that satisfy Angular's current requirements, but in case these change, you can install `core-js` and import the reflection library in your `setupJest.ts`:
 ```typescript
 require('core-js/es/reflect');
 require('core-js/proposals/reflect-metadata');


### PR DESCRIPTION
# Summary

I've added documentation to the Troubleshooting section to provide some guidance on the use of the `emitDecoratorMetadata` compiler option for Angular 8 users as described in issue #288

## Checklist

- [X ] I added the documentation in `README.md`
