### PR TITLE
fix: refactor zone patch test method

### DIFF
--- a/example/src/app/app.component.spec.ts
+++ b/example/src/app/app.component.spec.ts
@@ -108,6 +108,34 @@ describe('AppComponent', () => {
     expect(arg2).toBe(2);
     done();
   });
+
+  it.each`
+    foo  | bar
+    ${1} | ${2}
+  `('it.each should work with table as a tagged template literal', ({ foo, bar }) => {
+    expect(foo).toBe(1);
+    expect(bar).toBe(2);
+  });
+
+  (it.each`
+    foo  | bar
+    ${1} | ${2}
+  ` as any)(
+    'it.each should work with table as a tagged template literal with done',
+    ({ foo, bar }, done) => {
+      expect(foo).toBe(1);
+      expect(bar).toBe(2);
+      done();
+    }
+  );
+
+  it.each`
+    foo  | bar
+    ${1} | ${2}
+  `('(async) it.each should work with table as a tagged template literal', async ({ foo, bar }) => {
+    expect(foo).toBe(1);
+    expect(bar).toBe(2);
+  });
 });
 
 test.todo('a sample todo');

--- a/src/zone-patch/index.js
+++ b/src/zone-patch/index.js
@@ -44,51 +44,27 @@ function wrapDescribeInZone(describeBody) {
 // Create a proxy zone in which to run `test` blocks so that the tests function
 // can retroactively install different zones.
 const testProxyZone = ambientZone.fork(new ProxyZoneSpec());
-function wrapTestInZone(testBody, eachArgs) {
+function wrapTestInZone(testBody) {
   if (testBody === undefined) {
     return;
   }
 
-  if (!eachArgs || eachArgs.length === 0 || eachArgs[0].length === 0) {
-    // If we are not handling `test.each`, then the parameter of `testBody`
-    // will be 0 or 1, if it is 1, then we need to return a function with
-    // done parameter
+  const wrappedFunc = function() {
+    return testProxyZone.run(testBody, null, arguments);
+  };
+  try {
+    Object.defineProperty(wrappedFunc, 'length', {
+      configurable: true,
+      writable: true,
+      enumerable: false
+    });
+    wrappedFunc.length = testBody.length;
+  } catch (e) {
     return testBody.length === 0
       ? () => testProxyZone.run(testBody, null)
       : done => testProxyZone.run(testBody, null, [done]);
-  } else {
-    // Dynamically create a Function to contain the same length
-    // of the parameters as the testBody
-    // For example:
-    // ```
-    // test.each([[1, 2]])('test.each', (arg1, arg2) => {});
-    // ```
-    // In this case we need to return a function like this
-    // ```
-    // return function(arg1, arg2) {
-    //   return testProxyZone.run(testBody, null, [arg1, arg2]);
-    // }
-    // ```
-    const len = eachArgs[0].length;
-    const args = [];
-    let argString = '';
-    for (let i = 0; i < len; i++) {
-      args.push('arg' + i);
-      argString += 'arg' + i;
-      if (i !== len - 1) {
-        argString += ', ';
-      }
-    }
-    args.push('testBody');
-    args.push('testProxyZone');
-    if (len < testBody.length) {
-      args.push('done');
-      argString += ', done';
-    }
-    const funcBody = `
-      return testProxyZone.run(testBody, null, [${argString}])`;
-    return new Function(args, funcBody);
   }
+  return wrappedFunc;
 }
 
 /**
@@ -108,29 +84,7 @@ const bindDescribe = originalJestFn =>
 const bindTest = originalJestFn =>
   function(...eachArgs) {
     return function(...args) {
-      const testBody = args[1];
-      if (
-        testBody.length > 0 &&
-        Array.isArray(eachArgs) &&
-        eachArgs.length > 0 &&
-        eachArgs[0].length > 0
-      ) {
-        // check whether eachArgs is a 1D array
-        if (!Array.isArray(eachArgs[0][0])) {
-          // transfer eachArgs from 1D to 2D array
-          eachArgs = eachArgs.map(row => row.map(a => [a]));
-        }
-      }
-      args[1] = wrapTestInZone(args[1], ...eachArgs);
-      if (testBody.length > 0 || (eachArgs.length > 0 && eachArgs[0].length > 0)) {
-        eachArgs.forEach(row => {
-          const modifiedRow = row.map(a => {
-            a.push(testBody);
-            a.push(testProxyZone);
-          });
-          return modifiedRow;
-        });
-      }
+      args[1] = wrapTestInZone(args[1]);
       return originalJestFn.apply(this, eachArgs).apply(this, args);
     };
   };


### PR DESCRIPTION
refactor the zone.js patch test method logic to handle all cases
1. each with args
2. each with args and done
3. each with template string
4. each with template string and done

Close #359.