### PR TITLE
feat: angular ctor params transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog (master)
 
+#### Features
+
+* Use Angular constructor parameters transformer ([#406](https://github.com/thymikee/jest-preset-angular/pull/406))
+
 ### v8.2.1
 
 #### Features

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you look at your `src/test.ts` (or similar bootstrapping test file) file you'
 
 Example:
 
-`calc-component.spec.ts`
+`calc.component.spec.ts`
 
 ```ts
 // some initialization code
@@ -125,8 +125,6 @@ exports[`CalcComponent should snap 1`] = `
 >
   <p
     class="a-default-class"
-    ng-reflect-klass="a-default-class"
-    ng-reflect-ng-class="[object Object]"
   >
     calc works!
   </p>
@@ -234,7 +232,7 @@ Problems may arise if you're using custom builds (this preset is tailored for `a
 
 ### Can't resolve all parameters for SomeClass(?)
 
-With Angular 8 and higher, a [change to the way the Angular CLI works](https://github.com/thymikee/jest-preset-angular/issues/288) may be causing your metadata to be lost.  You can update your `tsconfig.spec.json` to include the `emitDecoratorMetadata` compiler option:
+With Angular 8 and higher, a [change to the way the Angular CLI works](https://github.com/thymikee/jest-preset-angular/issues/288) may be causing your metadata to be lost. If you do *not* use `isolatedModules: true` in your `tsconfig.spec.json`, the `jest-preset-angular` transformers handle this the Angular way. If you do compile with isolated modules, you can update your `tsconfig.spec.json` to include the `emitDecoratorMetadata` compiler option:
 
 ```
   "compilerOptions": {

--- a/example/jest.config.js
+++ b/example/jest.config.js
@@ -1,10 +1,5 @@
 module.exports = {
   preset: "jest-preset-angular",
-  snapshotSerializers: [
-    "jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js",
-    "jest-preset-angular/build/AngularSnapshotSerializer.js",
-    "jest-preset-angular/build/HTMLCommentSerializer.js"
-  ],
   moduleNameMapper: {
     "\\.(jpg|jpeg|png)$": "<rootDir>/__mocks__/image.js",
     "^@lib/(.*)$": "<rootDir>/src/lib/$1"

--- a/example/tsconfig.spec.json
+++ b/example/tsconfig.spec.json
@@ -4,7 +4,6 @@
     "outDir": "./out-tsc/spec",
     "module": "commonjs",
     "types": ["jest", "node"],
-    "emitDecoratorMetadata": true,
     "allowJs": true
   },
   "include": [

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5074,7 +5074,7 @@ jest-pnp-resolver@^1.2.1:
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
 "jest-preset-angular@file:..":
-  version "8.2.0"
+  version "8.2.1"
   dependencies:
     pretty-format "^26.0.0"
     ts-jest "^26.0.0"

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -6,6 +6,7 @@ module.exports = {
       astTransformers: [
         'jest-preset-angular/build/InlineFilesTransformer',
         'jest-preset-angular/build/StripStylesTransformer',
+        'jest-preset-angular/build/AngularConstructorParametersTransformer',
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "peerDependencies": {
     "@angular/core": ">=2.0.0",
     "@angular/platform-browser-dynamic": ">=2.0.0",
+    "@ngtools/webpack": "^9.1.10",
     "jest": "^26.0.0"
   },
   "jest": {

--- a/src/AngularConstructorParametersTransformer.ts
+++ b/src/AngularConstructorParametersTransformer.ts
@@ -1,0 +1,71 @@
+import type {
+  TransformerFactory,
+  SourceFile,
+  TransformationContext,
+  Program,
+} from "typescript";
+import { ConfigSet } from "ts-jest/dist/config/config-set";
+
+function tryLoadV8V9Transformer(
+  program: Program
+): TransformerFactory<SourceFile> | undefined {
+  try {
+    const {
+      downlevelConstructorParameters,
+    } = require("@ngtools/webpack/src/transformers/ctor-parameters");
+
+    return downlevelConstructorParameters(() => program.getTypeChecker());
+  } catch (err) {
+    return undefined;
+  }
+}
+
+function tryLoadV10Transformer(
+  program: Program
+): TransformerFactory<SourceFile> | undefined {
+  try {
+    const {
+      constructorParametersDownlevelTransform,
+    } = require("@angular/compiler-cli/src/tooling");
+
+    return (context: TransformationContext) => {
+      const compilerCliFactory = constructorParametersDownlevelTransform(
+        program
+      );
+      return compilerCliFactory(context);
+    };
+  } catch (err) {
+    return undefined;
+  }
+}
+
+/**
+ * The factory of hoisting transformer factory
+ * @internal
+ */
+export function factory(configSet: ConfigSet): TransformerFactory<SourceFile> {
+  const { program } = configSet.tsCompiler;
+  if (!program) {
+    throw new Error(
+      "TypeScript Compiler module is not provided! Please do not use the `AngularConstructorParametersTransformer` with `isolatedModules: true`"
+    );
+  }
+
+  // Depending on the used Angular version, we have to load the constructor parameters transformer from different locations
+
+  // Angular v8/v9 downlevel constructor transformer
+  let transformerFactory = tryLoadV8V9Transformer(program);
+
+  // Angular v10+ downlevel constructor transformer
+  if (transformerFactory === undefined) {
+    transformerFactory = tryLoadV10Transformer(program);
+  }
+
+  if (transformerFactory === undefined) {
+    throw new Error(
+      "Could not load Constructor Parameters Downlevel Transformer!"
+    );
+  }
+
+  return transformerFactory;
+}

--- a/src/InlineFilesTransformer.ts
+++ b/src/InlineFilesTransformer.ts
@@ -23,7 +23,7 @@
  */
 
 // only import types, for the rest use injected `ConfigSet.compilerModule`
-import {
+import type {
   Node,
   SourceFile,
   TransformationContext,
@@ -32,7 +32,11 @@ import {
   PropertyAssignment,
   Identifier
 } from 'typescript';
-import { getCreateStringLiteral, ConfigSet } from './TransformUtils';
+import type * as _ts from 'typescript';
+import type { ConfigSet } from 'ts-jest/dist/config/config-set';
+import { getCreateStringLiteral } from './TransformUtils';
+
+type TTypeScript = typeof _ts;
 
 // replace original ts-jest ConfigSet with this simple interface, as it would require
 // jest-preset-angular to add several babel devDependencies to get the other types
@@ -53,23 +57,10 @@ const REQUIRE = 'require';
 const TRANSFORM_PROPS = [TEMPLATE_URL, STYLE_URLS];
 
 /**
- * Transformer ID
- * @internal
- */
-export const name = 'angular-component-inline-files';
-
-// increment this each time the code is modified
-/**
- * Transformer Version
- * @internal
- */
-export const version = 1;
-
-/**
  * The factory of hoisting transformer factory
  * @internal
  */
-export function factory(cs: ConfigSet) {
+export function factory(cs: ConfigSet & { compilerModule: TTypeScript }) {
   /**
    * Our compiler (typescript, or a module with typescript-like interface)
    */
@@ -95,7 +86,7 @@ export function factory(cs: ConfigSet) {
    * Clones the assignment and manipulates it depending on its name.
    * @param node the property assignment to change
    */
-  function transfromPropertyAssignmentForJest(node: PropertyAssignment) {
+  function transformPropertyAssignmentForJest(node: PropertyAssignment) {
     const mutableAssignment = ts.getMutableClone(node);
 
     const assignmentNameText = (mutableAssignment.name as Identifier).text;
@@ -156,7 +147,7 @@ export function factory(cs: ConfigSet) {
       // this is an assignment which we want to transform
       if (isPropertyAssignmentToTransform(node)) {
         // get transformed node with changed properties
-        resultNode = transfromPropertyAssignmentForJest(node);
+        resultNode = transformPropertyAssignmentForJest(node);
       }
 
       // look for interesting assignments inside this node in any case

--- a/src/StripStylesTransformer.ts
+++ b/src/StripStylesTransformer.ts
@@ -22,7 +22,7 @@
  */
 
 // only import types, for the rest use injected `ConfigSet.compilerModule`
-import {
+import type {
   Node,
   SourceFile,
   TransformationContext,
@@ -34,7 +34,10 @@ import {
   CallExpression,
   ObjectLiteralExpression
 } from 'typescript';
-import { ConfigSet } from './TransformUtils';
+import type * as _ts from 'typescript';
+import type { ConfigSet } from 'ts-jest/dist/config/config-set';
+
+type TTypeScript = typeof _ts;
 
 /** Angular component decorator Styles property name */
 const STYLES = 'styles';
@@ -44,23 +47,10 @@ const COMPONENT = 'Component';
 const TRANSFORM_IN_DECORATOR_PROPS = [STYLES];
 
 /**
- * Transformer ID
- * @internal
- */
-export const name = 'angular-component-strip-styles';
-
-// increment this each time the code is modified
-/**
- * Transformer Version
- * @internal
- */
-export const version = 1;
-
-/**
  * The factory of hoisting transformer factory
  * @internal
  */
-export function factory(cs: ConfigSet) {
+export function factory(cs: ConfigSet & { compilerModule: TTypeScript }) {
   /**
    * Our compiler (typescript, or a module with typescript-like interface)
    */

--- a/src/TransformUtils.ts
+++ b/src/TransformUtils.ts
@@ -1,11 +1,7 @@
-import * as TS from 'typescript';
+import type * as _ts from 'typescript';
+type TTypeScript = typeof _ts;
+type CreateStringLiteral = typeof _ts.createStringLiteral;
 
-// replace original ts-jest ConfigSet with this simple interface, as it would require
-// jest-preset-angular to add several babel devDependencies to get the other types
-// inside the ConfigSet right
-export interface ConfigSet {
-  compilerModule: typeof TS;
-}
 
 /**
  * returns the compiler function to create a string literal. If an old version
@@ -14,13 +10,13 @@ export interface ConfigSet {
  * @param ts TypeScript compiler module
  */
 export function getCreateStringLiteral(
-  ts: typeof TS
-): typeof TS.createStringLiteral {
+  ts: TTypeScript
+): CreateStringLiteral {
   if (ts.createStringLiteral && typeof ts.createStringLiteral === 'function') {
     return ts.createStringLiteral;
   }
   return function createStringLiteral(text: string) {
-    const node = <TS.StringLiteral>(
+    const node = <_ts.StringLiteral>(
       ts.createNode(ts.SyntaxKind.StringLiteral, -1, -1)
     );
     node.text = text;


### PR DESCRIPTION
Introduces the usage of the @ngtools/webpack ctor-params transformer to
downlevel angular decorators to static properties

This also is the first usage of an Angular transformer in our setup. By using the compilation tools provided by the Angular Team to compile the code, we ensure the tests treat the code like production code. Furthermore this facilitates keeping up with the Angular Team.

### Checklist
- [X] Transformer using Angular's ctor-params
- [x] documentation in `README.md` regarding `isolatedModules: true`
- [x] update `CHANGELOG.md`
- [ ] Test for the transformer

Closes #288.


### Further Discussion
While we are finally able to include Angular transformers, and in this case to circumvent the issue with emitting more metadata than Angular itself, we are still behind Angular Ivy compilation in jest + angular. This could change if we take a better look at the compilation behavior of the [AngularCompilerPlugin](https://github.com/angular/angular-cli/blob/master/packages/ngtools/webpack/src/angular_compiler_plugin.ts) as well as the used [transformers](https://github.com/angular/angular-cli/tree/master/packages/ngtools/webpack/src/transformers). While partial functionality is definitely not interesting in test scenarios, other features are necessary. There might also be more compiling functionality in `@angular/compiler-cli`. More research has to be done in this field.

### Note for Compatibility with Angular v10
In Angular v10 the `ctor-parameters.js` disappeared (in [this commit](https://github.com/angular/angular-cli/commit/0a0be3b37b2daa8b77887e3873050f667fef4ce1)). The reference in the `AngularConstructorParameters` has to be updated to be compatible with Angular v10 (and therefore incompatible with Angular v9). The current transformer handles both scenarios by trying to load `ctor-parameters` first and then falling back to the newer `compiler-cli` transformer.