### PR TITLE
Updated the astTransformers option in jest.config.js to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ module.exports = {
     'ts-jest': {
       tsConfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.html$',
-      astTransformers: [
-        'jest-preset-angular/build/InlineFilesTransformer',
-        'jest-preset-angular/build/StripStylesTransformer'
-      ],
+      astTransformers: {
+        'before': [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer'
+        ]
+      }
     },
   },
   transform: {

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -3,10 +3,12 @@ module.exports = {
     'ts-jest': {
       tsConfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.html$',
-      astTransformers: [
-        'jest-preset-angular/build/InlineFilesTransformer',
-        'jest-preset-angular/build/StripStylesTransformer',
-      ],
+      astTransformers: {
+        'before': [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer'
+        ]
+      }
     },
   },
   transform: {


### PR DESCRIPTION
## Summary

TS-Jest has updated the AST Transformers option, explained [here](https://kulshekhar.github.io/ts-jest/user/config/astTransformers#writing-custom-typescript-ast-transformers). Previously, you could add Transformers in a `string[]` array. This is now deprecated. Now, you should use a `object` syntax. This PR updates the `readme` and the `jest.config.js` file to reflect this update.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
