### PR TITLE
refactor(config): use `readConfiguration` from `@angular/compiler-cli`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,13 @@
 /** @typedef {import('ts-jest')} */
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  preset: 'ts-jest',
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.spec.json',
     },
+  },
+  transform: {
+    '\\.ts$': '<rootDir>/build/index.js',
   },
   testPathIgnorePatterns: ['/e2e/'],
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "jest": "^26.0.0"
   },
   "devDependencies": {
+    "@angular/compiler": "^10.1.4",
+    "@angular/compiler-cli": "^10.1.4",
     "@angular/core": "^10.0.14",
     "@commitlint/cli": "11.x",
     "@commitlint/config-angular": "11.x",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "ts-jest": "^26.2.0"
   },
   "peerDependencies": {
-    "@angular/core": ">=8.0.0",
-    "@angular/platform-browser-dynamic": ">=8.0.0",
+    "@angular/core": ">=9.0.0",
+    "@angular/platform-browser-dynamic": ">=9.0.0",
     "jest": "^26.0.0"
   },
   "devDependencies": {

--- a/src/__tests__/__snapshots__/ng-jest-config.spec.ts.snap
+++ b/src/__tests__/__snapshots__/ng-jest-config.spec.ts.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NgJestConfig readTsConfig should return config including Angular compiler config with tsconfig as a string from ts-jest option 1`] = `
+Object {
+  "composite": undefined,
+  "declaration": false,
+  "declarationDir": undefined,
+  "declarationMap": undefined,
+  "emitDeclarationOnly": undefined,
+  "enableIvy": false,
+  "fullTemplateTypeCheck": true,
+  "inlineSourceMap": false,
+  "inlineSources": true,
+  "module": 1,
+  "noEmit": false,
+  "out": undefined,
+  "outFile": undefined,
+  "removeComments": false,
+  "sourceMap": true,
+  "sourceRoot": undefined,
+  "strictInjectionParameters": true,
+  "target": 1,
+  "tsBuildInfoFile": undefined,
+}
+`;
+
+exports[`NgJestConfig readTsConfig should return config including Angular compiler config with tsconfig as an object from ts-jest option 1`] = `
+Object {
+  "composite": undefined,
+  "declaration": false,
+  "declarationDir": undefined,
+  "declarationMap": undefined,
+  "emitDeclarationOnly": undefined,
+  "enableIvy": true,
+  "fullTemplateTypeCheck": true,
+  "inlineSourceMap": false,
+  "inlineSources": true,
+  "module": 1,
+  "noEmit": false,
+  "out": undefined,
+  "outFile": undefined,
+  "removeComments": false,
+  "resolveJsonModule": true,
+  "sourceMap": true,
+  "sourceRoot": undefined,
+  "strictInjectionParameters": true,
+  "target": 1,
+  "tsBuildInfoFile": undefined,
+}
+`;
+
+exports[`NgJestConfig readTsConfig should return config including Angular compiler config without tsconfig defined in ts-jest option 1`] = `
+Object {
+  "composite": undefined,
+  "declaration": false,
+  "declarationDir": undefined,
+  "declarationMap": undefined,
+  "emitDeclarationOnly": undefined,
+  "enableIvy": true,
+  "esModuleInterop": true,
+  "forceConsistentCasingInFileNames": true,
+  "importHelpers": true,
+  "importsNotUsedAsValues": 2,
+  "inlineSourceMap": false,
+  "inlineSources": true,
+  "lib": Array [
+    "lib.esnext.d.ts",
+    "lib.dom.d.ts",
+  ],
+  "module": 1,
+  "noEmit": false,
+  "noFallthroughCasesInSwitch": true,
+  "noImplicitReturns": true,
+  "noUnusedLocals": true,
+  "noUnusedParameters": true,
+  "out": undefined,
+  "outFile": undefined,
+  "removeComments": false,
+  "skipLibCheck": true,
+  "sourceMap": true,
+  "sourceRoot": undefined,
+  "strict": true,
+  "target": 1,
+  "tsBuildInfoFile": undefined,
+  "types": Array [
+    "node",
+    "jest",
+  ],
+}
+`;

--- a/src/__tests__/ng-jest-config.spec.ts
+++ b/src/__tests__/ng-jest-config.spec.ts
@@ -1,0 +1,63 @@
+import { NgJestConfig } from '../config/ng-jest-config';
+import { join } from 'path';
+
+describe('NgJestConfig', () => {
+  describe('readTsConfig', () => {
+    test('should return config including Angular compiler config with tsconfig as a string from ts-jest option', () => {
+      const configFilePath = join(__dirname, 'tsconfig-fake.json');
+      const ngJestConfig = new NgJestConfig({
+        globals: {
+          'ts-jest': {
+            tsconfig: configFilePath,
+          },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      const config = ngJestConfig.readTsConfig();
+
+      expect(config.fileNames).toBeDefined();
+      delete config.options.basePath;
+      delete config.options.baseUrl;
+      expect(config.options.configFilePath).toEqual(configFilePath);
+      delete config.options.configFilePath;
+      delete config.options.genDir;
+      expect(config.options).toMatchSnapshot();
+    });
+
+    test('should return config including Angular compiler config with tsconfig as an object from ts-jest option', () => {
+      const ngJestConfig = new NgJestConfig({
+        cwd: __dirname,
+        globals: {
+          'ts-jest': {
+            tsconfig: {
+              resolveJsonModule: true,
+            },
+          },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      const config = ngJestConfig.readTsConfig();
+
+      expect(config.fileNames).toBeDefined();
+      delete config.options.basePath;
+      delete config.options.baseUrl;
+      expect(config.options.configFilePath).toEqual(join(__dirname, 'tsconfig.json'));
+      delete config.options.configFilePath;
+      delete config.options.genDir;
+      expect(config.options).toMatchSnapshot();
+    });
+
+    test('should return config including Angular compiler config without tsconfig defined in ts-jest option', () => {
+      const ngJestConfig = new NgJestConfig(Object.create(null));
+      const config = ngJestConfig.readTsConfig();
+
+      expect(config.fileNames).toBeDefined();
+      delete config.options.basePath;
+      delete config.options.baseUrl;
+      expect(config.options.configFilePath).toEqual(join(process.cwd(), 'tsconfig.json'));
+      delete config.options.configFilePath;
+      delete config.options.genDir;
+      expect(config.options).toMatchSnapshot();
+    });
+  });
+});

--- a/src/__tests__/tsconfig-fake.json
+++ b/src/__tests__/tsconfig-fake.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": ["../__tests__"],
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableIvy": false
+  }
+}

--- a/src/__tests__/tsconfig.json
+++ b/src/__tests__/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": ["../__tests__"],
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true
+  }
+}

--- a/src/config/ng-jest-config.ts
+++ b/src/config/ng-jest-config.ts
@@ -1,0 +1,81 @@
+import type { ParsedConfiguration } from '@angular/compiler-cli';
+import { formatDiagnostics, readConfiguration } from '@angular/compiler-cli';
+import type { Config } from '@jest/types';
+import { ParsedCommandLine, ModuleKind, ScriptTarget } from 'typescript';
+
+import { ConfigSet } from 'ts-jest/dist/config/config-set';
+
+/**
+ * Temporary interface to make sure that `ts-jest` LanguageService still works. Once we use Angular Compiler, this
+ * interface can be removed
+ */
+interface ExtendedParsedConfiguration extends ParsedConfiguration {
+  fileNames: string[];
+}
+
+export class NgJestConfig extends ConfigSet {
+  constructor(public jestConfig: Config.ProjectConfig) {
+    super(jestConfig);
+  }
+
+  readTsConfig(): ExtendedParsedConfiguration {
+    const { globals } = this.jestConfig;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const extraTsconfig: string | ParsedCommandLine | undefined =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      globals && globals['ts-jest'] ? (globals as Record<string, any>)['ts-jest'].tsconfig : undefined;
+    let config!: ParsedConfiguration;
+    /**
+     * By default, readConfiguration will pick up `tsconfig.json` from current directory. Because we are getting config
+     * via `ts-jest`, we need to manually get `tsconfig` from `ts-jest` options from `jest` config.
+     */
+    if (typeof extraTsconfig === 'string') {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error `ts-jest` doesn't expose typing for resolvePath
+      config = readConfiguration(super.resolvePath(extraTsconfig));
+    } else {
+      config = readConfiguration(this.jestConfig.cwd ?? process.cwd());
+      if (extraTsconfig) {
+        config = {
+          ...config,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          options: {
+            ...config.options,
+            ...extraTsconfig,
+          } as Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
+        };
+      }
+    }
+    if (config.errors?.length) {
+      throw new Error(formatDiagnostics(config.errors));
+    }
+
+    /**
+     * Temporary return this type of object as well as all override compiler options so that `ts-jest` compilation
+     * still works
+     */
+    return {
+      ...config,
+      options: {
+        ...config.options,
+        target: ScriptTarget.ES5,
+        module: ModuleKind.CommonJS,
+        sourceMap: true,
+        inlineSourceMap: false,
+        inlineSources: true,
+        declaration: false,
+        noEmit: false,
+        removeComments: false,
+        out: undefined,
+        outFile: undefined,
+        composite: undefined,
+        declarationDir: undefined,
+        declarationMap: undefined,
+        emitDeclarationOnly: undefined,
+        sourceRoot: undefined,
+        tsBuildInfoFile: undefined,
+      },
+      fileNames: config.rootNames,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,53 @@
 import type { TransformedSource, Transformer, TransformOptions } from '@jest/transform';
 import type { Config } from '@jest/types';
+import type { ConfigSet } from 'ts-jest/dist/config/config-set';
 import { TsJestTransformer } from 'ts-jest/dist/ts-jest-transformer';
 
+import { NgJestConfig } from './config/ng-jest-config';
+import { JsonableValue } from './utils/jsonable-value';
+import { stringify } from './utils/json';
+
+interface ConfigSetItem {
+  configSet: ConfigSet;
+  jestConfig: JsonableValue<Config.ProjectConfig>;
+}
+
 class AngularJestTransformer extends TsJestTransformer implements Transformer {
+  /**
+   * cache config within a process
+   */
+  private static readonly configSetItems: ConfigSetItem[] = [];
+
+  /**
+   * Copy from `ts-jest` and replace with NgJestConfig
+   */
+  configsFor(jestConfig: Config.ProjectConfig): ConfigSet {
+    let csi: ConfigSetItem | undefined = AngularJestTransformer.configSetItems.find(
+      (cs) => cs.jestConfig.value === jestConfig,
+    );
+    if (csi) return csi.configSet;
+    // try to look-it up by stringified version
+    const serialized = stringify(jestConfig);
+    csi = AngularJestTransformer.configSetItems.find((cs) => cs.jestConfig.serialized === serialized);
+    if (csi) {
+      // update the object so that we can find it later
+      // this happens because jest first calls getCacheKey with stringified version of
+      // the config, and then it calls the transformer with the proper object
+      csi.jestConfig.value = jestConfig;
+
+      return csi.configSet;
+    }
+    const jestConfigObj: Config.ProjectConfig = jestConfig;
+
+    const configSet = new NgJestConfig(jestConfigObj);
+    AngularJestTransformer.configSetItems.push({
+      jestConfig: new JsonableValue(jestConfigObj),
+      configSet,
+    });
+
+    return configSet;
+  }
+
   process(
     input: string,
     filePath: Config.Path,

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-redeclare */
+import stableStringify from 'fast-json-stable-stringify';
+
+const UNDEFINED = 'undefined';
+
+/**
+ * @internal
+ */
+export function stringify(input: unknown): string {
+  return input === undefined ? UNDEFINED : stableStringify(input);
+}

--- a/src/utils/jsonable-value.ts
+++ b/src/utils/jsonable-value.ts
@@ -1,0 +1,35 @@
+import { stringify } from './json';
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class JsonableValue<V = any> {
+  private _serialized!: string;
+  private _value!: V;
+
+  constructor(value: V) {
+    this.value = value;
+  }
+
+  set value(value: V) {
+    this._value = value;
+    this._serialized = stringify(value);
+  }
+
+  get value(): V {
+    return this._value;
+  }
+
+  get serialized(): string {
+    return this._serialized;
+  }
+
+  valueOf(): V {
+    return this._value;
+  }
+
+  toString(): string {
+    return this._serialized;
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,5 +3,7 @@
   "compilerOptions": {
     "target": "ES5"
   },
-  "include": [] // boost test's speed trick
+  "include": [
+    "src"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,32 @@
 # yarn lockfile v1
 
 
+"@angular/compiler-cli@^10.1.4":
+  version "10.1.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-10.1.4.tgz#b5aaa7de6173b83ce3ba066232b8c088f2428642"
+  integrity sha512-5jRL9TKSGQLlP+C3gdJmSjYv7BfzN69SuYir/o0OtBblqzsGeaA21ClPMXl/HOxjFSjnIyGgjN7Caf7VjeMJww==
+  dependencies:
+    canonical-path "1.0.0"
+    chokidar "^3.0.0"
+    convert-source-map "^1.5.1"
+    dependency-graph "^0.7.2"
+    fs-extra "4.0.2"
+    magic-string "^0.25.0"
+    minimist "^1.2.0"
+    reflect-metadata "^0.1.2"
+    semver "^6.3.0"
+    source-map "^0.6.1"
+    sourcemap-codec "^1.4.8"
+    tslib "^2.0.0"
+    yargs "15.3.0"
+
+"@angular/compiler@^10.1.4":
+  version "10.1.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-10.1.4.tgz#76268332edb289b282296560e41478a2e323a39c"
+  integrity sha512-3vkaLE1kfyfkNoU/sf982UBMtB1bvFgBKHdP+YG7qlxVL1nLlQQvzIHKV8YGgtWnK2PMoJMI51In/64M71T0hg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@angular/core@^10.0.14":
   version "10.1.4"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.1.4.tgz#1180370e335371a0c36f05c2e8142c926a362836"
@@ -980,7 +1006,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
   integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
@@ -1177,6 +1203,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1201,7 +1232,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1298,6 +1329,11 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
+canonical-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/canonical-path/-/canonical-path-1.0.0.tgz#fcb470c23958def85081856be7a86e904f180d1d"
+  integrity sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -1339,6 +1375,21 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chokidar@^3.0.0:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1640,7 +1691,7 @@ conventional-commits-parser@^3.0.0, conventional-commits-parser@^3.1.0:
     through2 "^3.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -1828,6 +1879,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+dependency-graph@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.7.2.tgz#91db9de6eb72699209d88aea4c1fd5221cac1c49"
+  integrity sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2352,6 +2408,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-extra@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
+  integrity sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
@@ -2367,7 +2432,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.1.2:
+fsevents@^2.1.2, fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
@@ -2494,7 +2559,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -2774,6 +2839,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -2860,7 +2932,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -3500,6 +3572,13 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
@@ -3721,6 +3800,13 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+magic-string@^0.25.0:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -4012,7 +4098,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -4527,6 +4613,13 @@ readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -4557,6 +4650,11 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+reflect-metadata@^0.1.2:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.7"
@@ -4972,6 +5070,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -5480,6 +5583,11 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
 universalify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
@@ -5708,13 +5816,30 @@ yargs-parser@20.x:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.0.tgz#944791ca2be2e08ddadd3d87e9de4c6484338605"
   integrity sha512-2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==
 
-yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@^18.1.0, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs@15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.0.tgz#403af6edc75b3ae04bf66c94202228ba119f0976"
+  integrity sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.0"
 
 yargs@^15.1.0, yargs@^15.3.1:
   version "15.4.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Introduce `NgJestConfig` which extends `ts-jest` config class `ConfigSet` and use `readConfiguration` to read tsconfig and get Angular compiler configs.

With [readConfiguration function](https://github.com/angular/angular/blob/master/packages/compiler-cli/src/perform_compile.ts#L141) we are assured that we have similar tsconfig as well as [Angular compiler options](https://angular.io/guide/angular-compiler-options) like Angular CLI does. Later this config will be required to use with Angular compiler.

Next step will be: to check which options will be overwritten in https://github.com/angular/angular-cli/blob/master/packages/ngtools/webpack/src/angular_compiler_plugin.ts#L161

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
