### PR TITLE
refactor(preset): explicitly define `jsdom` for test environment

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -11,6 +11,7 @@ module.exports = {
       },
     },
   },
+  testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(ts|js|html)$': 'ts-jest',
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^26.5.0",
+    "jest-environment-jsdom": "^26.6.2",
     "pretty-format": "26.x",
     "ts-jest": "^26.2.0"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Jest 27 sets default test environment to `node`, see https://github.com/facebook/jest/pull/9874. Since we need `jsdom` so we need to explicitly set it in `jest-preset.js`.

Jest 27 will still bundle `jest-environment-jsdom` in the main package and Jest 28 will separate them. However, we should just go ahead and set explicitly `jest-environment-jsdom` in our dependencies list.

More information see https://jestjs.io/blog/2020/05/05/jest-26


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A>**
