### PR TITLE
chore: drop support for Angular 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ts-jest": "^26.2.0"
   },
   "peerDependencies": {
-    "@angular/core": ">=8.0.0",
-    "@angular/platform-browser-dynamic": ">=8.0.0",
+    "@angular/core": ">=9.0.0",
+    "@angular/platform-browser-dynamic": ">=9.0.0",
     "jest": "^26.0.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Angular 8 support policy ended on 28th Nov 2020

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

`jest-preset-angular` now requires Angular 9+. If you are using Angular 8, please use **v8.3.2**

## Other information
**N.A.**
