### PR TITLE
perf(compiler): reuse `cacheFS` from jest to reduce file system reading

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -10,6 +10,7 @@ describe('NgJestTransformer', () => {
       () => {
         const obj1 = {
           config: { cwd: process.cwd(), extensionsToTreatAsEsm: [], globals: {}, testMatch: [], testRegex: [] },
+          cacheFS: new Map(),
         };
         const obj2 = { ...obj1, config: { ...obj1.config, globals: {} } };
         // eslint-disable-next-line
@@ -24,6 +25,7 @@ describe('NgJestTransformer', () => {
     test('should return the same config set for same values with jest config objects', () => {
       const obj1 = {
         config: { cwd: process.cwd(), extensionsToTreatAsEsm: [], globals: {}, testMatch: [], testRegex: [] },
+        cacheFS: new Map(),
       };
       const obj2 = { ...obj1 };
       // eslint-disable-next-line
@@ -84,7 +86,7 @@ describe('NgJestTransformer', () => {
       const input = {
         fileContent: 'const foo = 1',
         // eslint-disable-next-line
-        options: { config: { ...jestCfg } as any, instrument: false, rootDir: '/foo' },
+        options: { config: { ...jestCfg } as any, instrument: false, rootDir: '/foo', cacheFS: new Map(), },
       };
       // eslint-disable-next-line
       const ngJestTransformer = require('../');
@@ -121,7 +123,7 @@ describe('NgJestTransformer', () => {
       };
       const input = {
         // eslint-disable-next-line
-        options: { config: { ...jestCfg } as any, instrument: false, rootDir: '/foo' },
+        options: { config: { ...jestCfg } as any, instrument: false, rootDir: '/foo', cacheFS: new Map(), },
       };
       // eslint-disable-next-line
       const ngJestTransformer = require('../');

--- a/src/__tests__/ng-jest-compiler.spec.ts
+++ b/src/__tests__/ng-jest-compiler.spec.ts
@@ -45,7 +45,7 @@ describe('NgJestCompiler', () => {
     // Isolated modules true doesn't have downlevel ctor so this snapshot test should produce different input than with Program
     test('should return result', () => {
       const fileName = join(__dirname, '__mocks__', 'foo.service.ts');
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8'))!;
@@ -60,7 +60,7 @@ describe('NgJestCompiler', () => {
         ...ngJestConfig.parsedTsConfig,
         rootNames: [fileName],
       };
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8'))!;
@@ -79,7 +79,7 @@ describe('NgJestCompiler', () => {
         ...ngJestConfig.parsedTsConfig,
         rootNames: [],
       };
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const emittedResult = compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8'))!;
@@ -94,7 +94,7 @@ describe('NgJestCompiler', () => {
         ...ngJestConfig.parsedTsConfig,
         rootNames: [fileName],
       };
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const emittedResult = compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8'))!;
@@ -109,7 +109,7 @@ describe('NgJestCompiler', () => {
         ...ngJestConfig.parsedTsConfig,
         rootNames: [],
       };
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       expect(() =>
         compiler.getCompiledOutput('foo.ts', readFileSync(fileName, 'utf-8')),
@@ -122,7 +122,7 @@ describe('NgJestCompiler', () => {
         ...ngJestConfig.parsedTsConfig,
         rootNames: [fileName],
       };
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       expect(() =>
         compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8')),
@@ -136,7 +136,7 @@ describe('NgJestCompiler', () => {
         rootNames: [fileName],
       };
       ngJestConfig.shouldReportDiagnostics = jest.fn().mockReturnValueOnce(false);
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       expect(() => compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8'))).not.toThrowError();
     });
@@ -148,7 +148,7 @@ describe('NgJestCompiler', () => {
         ...ngJestConfig.parsedTsConfig,
         rootNames: [fileName],
       };
-      const compiler = new NgJestCompiler(ngJestConfig);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const emittedResult = compiler.getCompiledOutput(fileName, readFileSync(fileName, 'utf-8'))!;

--- a/src/compiler/ng-jest-compiler.ts
+++ b/src/compiler/ng-jest-compiler.ts
@@ -18,7 +18,7 @@ export class NgJestCompiler implements CompilerInstance {
   private readonly _logger: Logger;
   private readonly _ts: TTypeScript;
 
-  constructor(readonly ngJestConfig: NgJestConfig) {
+  constructor(readonly ngJestConfig: NgJestConfig, readonly jestCacheFS: Map<string, string>) {
     this._logger = this.ngJestConfig.logger;
     this._ts = this.ngJestConfig.compilerModule;
     this._setupOptions(this.ngJestConfig);
@@ -117,7 +117,7 @@ export class NgJestCompiler implements CompilerInstance {
         '_setupOptions: creating Compiler Host using @angular/compiler-cli createCompilerHost',
       );
 
-      this._tsHost = new NgJestCompilerHost(this._logger, this.ngJestConfig);
+      this._tsHost = new NgJestCompilerHost(this._logger, this.ngJestConfig, this.jestCacheFS);
       this._compilerHost = createCompilerHost({
         options: this._compilerOptions,
         tsHost: this._tsHost,

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ class NgJestTransformer extends TsJestTransformer {
         this._logger.info('no matching config-set found, creating a new one');
 
         ngJestConfig = new NgJestConfig(jestConfig);
-        this._compiler = new NgJestCompiler(ngJestConfig);
+        this._compiler = new NgJestCompiler(ngJestConfig, transformOptions.cacheFS);
         this._transformCfgStr = new JsonableValue({
           ...jestConfig,
           ...ngJestConfig.parsedTsConfig,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Reuse Jest `cacheFS` when reading files for compiler

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
