### PR TITLE
fix(watch mode): update SourceFile with fileContent

### DIFF
--- a/src/__tests__/__snapshots__/ng-jest-compiler.spec.ts.snap
+++ b/src/__tests__/__snapshots__/ng-jest-compiler.spec.ts.snap
@@ -20,6 +20,50 @@ export { AppComponent };
 //# "
 `;
 
+exports[`NgJestCompiler with isolatedModule false should compile new code when file changes: from hasErrorFileContent 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.AppComponent = void 0;
+const tslib_1 = require(\\"tslib\\");
+const core_1 = require(\\"@angular/core\\");
+let  = class  {
+    constructor() {
+        this. = ;
+    }
+};
+ = tslib_1.__decorate([
+    core_1.Component({
+        selector: 'app-root',
+        template: require(\\"./app.component.html\\"),
+        styles: []
+    })
+], );
+exports.AppComponent = ;
+//# "
+`;
+
+exports[`NgJestCompiler with isolatedModule false should compile new code when file changes: from noErrorFileContent 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.AppComponent = void 0;
+const tslib_1 = require(\\"tslib\\");
+const core_1 = require(\\"@angular/core\\");
+let AppComponent = class AppComponent {
+    constructor() {
+        this.title = 'test-app-v10';
+    }
+};
+AppComponent = tslib_1.__decorate([
+    core_1.Component({
+        selector: 'app-root',
+        template: require(\\"./app.component.html\\"),
+        styles: []
+    })
+], AppComponent);
+exports.AppComponent = AppComponent;
+//# "
+`;
+
 exports[`NgJestCompiler with isolatedModule false should throw diagnostics error for new file which is: known by Program 1`] = `"src/__tests__/__mocks__/foo.component.ts(8,3): error TS2322: Type 'string' is not assignable to type 'number'."`;
 
 exports[`NgJestCompiler with isolatedModule false should throw diagnostics error for new file which is: not known by Program 1`] = `"src/__tests__/__mocks__/foo.component.ts(8,3): error TS2322: Type 'string' is not assignable to type 'number'."`;

--- a/src/__tests__/ng-jest-compiler.spec.ts
+++ b/src/__tests__/ng-jest-compiler.spec.ts
@@ -123,6 +123,24 @@ describe('NgJestCompiler', () => {
       },
     );
 
+    test('should compile new code when file changes', () => {
+      const ngJestConfig = new NgJestConfig(jestCfgStub);
+      const compiler = new NgJestCompiler(ngJestConfig, new Map());
+
+      // Compile the same file with 2 versions of content: noErrorFileContent and hasErrorFileContent
+      const fileName = noErrorFileName;
+      const emittedResult1 = compiler.getCompiledOutput(fileName, noErrorFileContent, true);
+      expect(emittedResult1.substring(0, emittedResult1.indexOf(SOURCE_MAPPING_PREFIX))).toMatchSnapshot(
+        'from noErrorFileContent',
+      );
+      const emittedResult2 = compiler.getCompiledOutput(fileName, hasErrorFileContent, true);
+      expect(emittedResult2.substring(0, emittedResult2.indexOf(SOURCE_MAPPING_PREFIX))).toMatchSnapshot(
+        'from hasErrorFileContent',
+      );
+
+      expect(emittedResult1).not.toEqual(emittedResult2);
+    });
+
     test('should compile codes with useESM true', () => {
       const ngJestConfig = new NgJestConfig({
         ...jestCfgStub,

--- a/src/compiler/ng-jest-compiler.ts
+++ b/src/compiler/ng-jest-compiler.ts
@@ -4,7 +4,6 @@ import type { Logger } from 'bs-logger';
 import { updateOutput } from 'ts-jest/dist/compiler/compiler-utils';
 import type { CompilerInstance, TTypeScript, ResolvedModulesMap } from 'ts-jest/dist/types';
 import type * as ts from 'typescript';
-import { TextSpan } from 'typescript';
 
 import type { NgJestConfig } from '../config/ng-jest-config';
 import { constructorParametersDownlevelTransform } from '../transformers/downlevel-ctor';
@@ -85,7 +84,7 @@ export class NgJestCompiler implements CompilerInstance {
       } else {
         sourceFile = this._program.getSourceFile(fileName);
         if (sourceFile) {
-          const replaceSpan: TextSpan = { start: 0, length: sourceFile.text.length };
+          const replaceSpan: ts.TextSpan = { start: 0, length: sourceFile.text.length };
           sourceFile.update(fileContent, { span: replaceSpan, newLength: fileContent.length });
         }
       }


### PR DESCRIPTION
Previously `SourceFile.text` was the old contents of the file - the state of the file during startup. This change updates the SourceFile text so that emit() receives the changed file contents.

fixes: #764 

## Test plan

I've tested this locally by copying the `build` dir into node_modules on 2 different projects (test repo and production repo) and verified. It would be ideal to create a unit test for this, but I'm not sure I'm up to that.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

