### PR TITLE
refactor(config): deprecate import serializer paths

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -23,8 +23,8 @@ module.exports = {
   },
   transformIgnorePatterns: ['node_modules/(?!@ngrx)'],
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js',
+    'jest-preset-angular/build/serializers/html-comment',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/no-ng-attributes',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@angular-eslint/eslint-plugin": "latest",
+    "@angular/core": "^9.1.13",
     "@commitlint/cli": "latest",
     "@commitlint/config-angular": "latest",
     "@types/jest": "26.x",
@@ -55,8 +56,11 @@
     "lint-staged": "latest",
     "lodash.memoize": "4.x",
     "prettier": "2.x",
+    "rxjs": "^6.6.6",
     "ts-jest": "26.x",
-    "typescript": "3.x"
+    "tslib": "1.14.1",
+    "typescript": "3.x",
+    "zone.js": "0.10.3"
   },
   "husky": {
     "hooks": {

--- a/src/AngularSnapshotSerializer.js
+++ b/src/AngularSnapshotSerializer.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const { rootLogger } = require('ts-jest/dist/utils/logger');
+
+rootLogger.warn("The snapshot serializer under import path `'jest-preset-angular/build/AngularSnapshotSerializer.js'` is deprecated and will be removed in v9.0.0. Please switch to `'jest-preset-angular/build/serializers/ng-snapshot'`")
+
 const printAttributes = (val, attributes, print, indent, colors, opts) => {
   return attributes
     .sort()

--- a/src/HTMLCommentSerializer.js
+++ b/src/HTMLCommentSerializer.js
@@ -9,6 +9,10 @@
 
 'use strict';
 
+const { rootLogger } = require('ts-jest/dist/utils/logger');
+
+rootLogger.warn("The snapshot serializer under import path `'jest-preset-angular/build/HTMLCommentSerializer.js'` is deprecated and will be removed in v9.0.0. Please switch to `'jest-preset-angular/build/serializers/html-comment'`")
+
 const HTML_ELEMENT_REGEXP = /Comment/;
 const test = (value) =>
   value !== undefined &&

--- a/src/serializers/html-comment.ts
+++ b/src/serializers/html-comment.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+const HTML_ELEMENT_REGEXP = /Comment/;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+const test = (value: any): boolean =>
+  value?.nodeType === 8 && value.constructor !== undefined && HTML_ELEMENT_REGEXP.test(value.constructor.name);
+
+const print = (): string => '';
+
+export = {
+  print,
+  test,
+};

--- a/src/serializers/index.ts
+++ b/src/serializers/index.ts
@@ -1,0 +1,5 @@
+export = [
+  'jest-preset-angular/build/serializers/html-comment',
+  'jest-preset-angular/build/serializers/ng-snapshot',
+  'jest-preset-angular/build/serializers/no-ng-attributes',
+];

--- a/src/serializers/ng-snapshot.ts
+++ b/src/serializers/ng-snapshot.ts
@@ -1,0 +1,134 @@
+import type { Type, ComponentRef, ɵCssSelectorList, DebugNode } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import type { Colors } from 'pretty-format';
+
+/**
+ * The follow interfaces are customized heavily inspired by @angular/core/core.d.ts
+ */
+interface ComponentDef {
+  selectors: ɵCssSelectorList;
+}
+interface VEComponentType extends Type<unknown> {
+  ngComponentDef: ComponentDef;
+}
+interface IvyComponentType extends Type<unknown> {
+  ɵcmp: ComponentDef;
+}
+interface NgComponentRef extends ComponentRef<unknown> {
+  _elDef: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  _view: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+interface NgComponentFixture extends ComponentFixture<unknown> {
+  componentRef: NgComponentRef;
+  componentInstance: Record<string, unknown>;
+}
+interface VEDebugNode {
+  renderElement: {
+    childNodes: DebugNode[];
+  };
+}
+
+/**
+ * The following types haven't been exported by jest so temporarily we copy typings from 'pretty-format'
+ */
+interface PluginOptions {
+  edgeSpacing: string;
+  min: boolean;
+  spacing: string;
+}
+type Indent = (indentSpaces: string) => string;
+type Printer = (elementToSerialize: unknown) => string;
+
+const printAttributes = (
+  val: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  attributes: string[],
+  _print: Printer,
+  indent: Indent,
+  colors: Colors,
+  opts: PluginOptions,
+): string => {
+  return attributes
+    .sort()
+    .map((attribute) => {
+      return (
+        opts.spacing +
+        indent(`${colors.prop.open}${attribute}${colors.prop.close}=`) +
+        colors.value.open +
+        (val.componentInstance[attribute] && val.componentInstance[attribute].constructor
+          ? `{[Function ${val.componentInstance[attribute].constructor.name}]}`
+          : `"${val.componentInstance[attribute]}"`) +
+        colors.value.close
+      );
+    })
+    .join('');
+};
+
+const ivyEnabled = (): boolean => {
+  // Should be required lazily, since it will throw an exception
+  // `Cannot resolve parameters...`.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
+  const { ɵivyEnabled } = require('@angular/core');
+
+  return !!ɵivyEnabled;
+};
+
+// Ivy component definition was stored on the `ngComponentDef`
+// property before `9.0.0-next.10`. Since `9.0.0-next.10` it was
+// renamed to `ɵcmp`.
+const getComponentDef = (type: VEComponentType | IvyComponentType): ComponentDef =>
+  (type as VEComponentType).ngComponentDef ?? (type as IvyComponentType).ɵcmp;
+
+const print = (
+  fixture: NgComponentFixture,
+  print: Printer,
+  indent: Indent,
+  opts: PluginOptions,
+  colors: Colors,
+): string => {
+  let nodes = '';
+  let componentAttrs = '';
+  let componentName = '';
+
+  if (ivyEnabled()) {
+    const componentDef = getComponentDef(fixture.componentRef.componentType as IvyComponentType);
+    componentName = componentDef.selectors[0][0] as string;
+    nodes = Array.from(fixture.componentRef.location.nativeElement.childNodes).map(print).join('');
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    componentName = fixture.componentRef._elDef.element?.name;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    nodes = (fixture.componentRef._view.nodes || [])
+      // eslint-disable-next-line no-prototype-builtins
+      .filter((node: VEDebugNode) => node?.hasOwnProperty('renderElement'))
+      .map((node: VEDebugNode) => Array.from(node.renderElement.childNodes).map(print).join(''))
+      .join(opts.edgeSpacing);
+  }
+  const attributes = Object.keys(fixture.componentInstance);
+  if (attributes.length) {
+    componentAttrs += printAttributes(fixture, attributes, print, indent, colors, opts);
+  }
+
+  return (
+    '<' +
+    componentName +
+    componentAttrs +
+    (componentAttrs.length ? '\n' : '') +
+    '>\n' +
+    indent(nodes) +
+    '\n</' +
+    componentName +
+    '>'
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+const test = (val: any): boolean =>
+  val !== undefined &&
+  val !== null &&
+  typeof val === 'object' &&
+  Object.prototype.hasOwnProperty.call(val, 'componentRef');
+
+export = {
+  print,
+  test,
+};

--- a/src/serializers/no-ng-attributes.ts
+++ b/src/serializers/no-ng-attributes.ts
@@ -1,13 +1,9 @@
-'use strict';
+import { plugins } from 'pretty-format';
 
-const { rootLogger } = require('ts-jest/dist/utils/logger');
-
-rootLogger.warn("The snapshot serializer under import path `'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js'` is deprecated and will be removed in v9.0.0. Please switch to `'jest-preset-angular/build/serializers/no-ng-attributes'`")
-
-const jestDOMElementSerializer = require('pretty-format').plugins.DOMElement;
+const jestDOMElementSerializer = plugins.DOMElement;
 
 const attributesToRemovePatterns = ['ng-reflect', '_nghost', '_ngcontent', 'ng-version'];
-const attributesToClean = {
+const attributesToClean: Record<string, RegExp[]> = {
   class: [/^(?:mat|cdk|ng).*-\w*\d+-\d+$/, /^ng-star-inserted$/], // e.g. "ng-tns-c25-1" or "ng-star-inserted", literally
   id: [/^(?:mat|cdk|ng).*-\d+$/], // e.g. "mat-input-4", "cdk-step-content-0-0"
   for: [/^(?:mat|cdk|ng).*-\d+$/], // e.g. "mat-form-field-label-9"
@@ -15,14 +11,14 @@ const attributesToClean = {
   'aria-labelledby': [/^(?:mat|cdk|ng).*-\d+$/], // e.g. "mat-input-4", "cdk-step-label-0-0"
   'aria-controls': [/^(?:mat|cdk|ng).*-\d+$/], // e.g. "cdk-step-content-2-0"
 };
-
-const hasAttributesToRemove = (attribute) =>
+const hasAttributesToRemove = (attribute: Attr): boolean =>
   attributesToRemovePatterns.some((removePattern) => attribute.name.startsWith(removePattern));
-const hasAttributesToClean = (attribute) =>
+const hasAttributesToClean = (attribute: Attr): boolean =>
   Object.keys(attributesToClean).some((removePatternKey) => attribute.name === removePatternKey);
 
-const serialize = (node, ...rest) => {
-  const nodeCopy = node.cloneNode(true);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+const serialize = (node: Element, ...rest: any): string => {
+  const nodeCopy = node.cloneNode(true) as Element;
   // Remove angular-specific attributes
   Object.values(nodeCopy.attributes)
     .filter(hasAttributesToRemove)
@@ -30,12 +26,12 @@ const serialize = (node, ...rest) => {
   // Remove angular auto-added classes
   Object.values(nodeCopy.attributes)
     .filter(hasAttributesToClean)
-    .forEach((attribute) => {
+    .forEach((attribute: Attr) => {
       attribute.value = attribute.value
         .split(' ')
         .filter(
-          (attrValue) =>
-            !attributesToClean[attribute.name].some((attributeCleanRegex) => attributeCleanRegex.test(attrValue))
+          (attrValue: string) =>
+            !attributesToClean[attribute.name].some((attributeCleanRegex) => attributeCleanRegex.test(attrValue)),
         )
         .join(' ');
       if (attribute.value === '') {
@@ -45,17 +41,19 @@ const serialize = (node, ...rest) => {
       }
     });
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
   return jestDOMElementSerializer.serialize(nodeCopy, ...rest);
 };
 
-const serializeTestFn = (val) =>
+const serializeTestFn = (val: Element): boolean =>
   val.attributes !== undefined &&
   Object.values(val.attributes).some(
-    (attribute) => hasAttributesToRemove(attribute) || hasAttributesToClean(attribute)
+    (attribute: Attr) => hasAttributesToRemove(attribute) || hasAttributesToClean(attribute),
   );
-const test = (val) => jestDOMElementSerializer.test(val) && serializeTestFn(val);
+const test = (val: Element): boolean => jestDOMElementSerializer.test(val) && serializeTestFn(val);
 
-module.exports = {
+export = {
   serialize,
   test,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     "@typescript-eslint/experimental-utils" "4.3.0"
 
+"@angular/core@^9.1.13":
+  version "9.1.13"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-9.1.13.tgz#a87bc5a7926a50aec0bfcead769078bc7f1b93fa"
+  integrity sha512-mBm24Q9GjkAsxMAzqQ86U1078+yTEpr0+syMEruUtJ0HUH6Fzn3J+6xTLb+BVcGb9RkCkFaV9T5mcn6ZM0f++g==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
@@ -5239,6 +5244,13 @@ rxjs@^6.6.2:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.6.6:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -5912,6 +5924,11 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -6312,3 +6329,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zone.js@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.10.3.tgz#3e5e4da03c607c9dcd92e37dd35687a14a140c16"
+  integrity sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
DEPRECATION
- Import serializer via `'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js'` is deprecated in favor of `'jest-preset-angular/build/serializers/no-ng-attributes'`
- Import serializer via `'jest-preset-angular/build/AngularSnapshotSerializer.js'` is deprecated in favor of `'jest-preset-angular/build/serializers/ng-snapshot'`
- Import serializer via `'jest-preset-angular/build/HTMLCommentSerializer.js'` is deprecated in favor of `'jest-preset-angular/build/serializers/html-comment'`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
