### PR TITLE
refactor(transformers): replace deprecated TypeScript methods for `replace-resources` AST transformer

### DIFF
--- a/e2e/__tests__/ast-transformers.test.ts
+++ b/e2e/__tests__/ast-transformers.test.ts
@@ -1,35 +1,19 @@
 import runJest from '../run-jest';
 import { onNodeVersions } from '../utils';
 
-test(`use hoisting ast transformer from 'ts-jest'`, () => {
-  const result = runJest('ast-transformers/hoisting');
-
-  expect(result.exitCode).toBe(0);
-});
-
-test(`use downlevel ctor ast transformer internally`, () => {
-  const result = runJest('ast-transformers/downlevel-ctor');
-
-  expect(result.exitCode).toBe(0);
-});
-
-test('use replace-resources ast transformer internally', () => {
-  const result = runJest('ast-transformers/replace-resources');
+const INTERNAL_TRANSFORMER_NAMES = ['downlevel-ctor', 'replace-resources'];
+test.each([
+  ...INTERNAL_TRANSFORMER_NAMES,
+  'hoisting', // from `ts-jest`
+])('use %s ast transformer in CJS mode', (astTransformerName) => {
+  const result = runJest(`ast-transformers/${astTransformerName}`);
 
   expect(result.exitCode).toBe(0);
 });
 
 onNodeVersions('^12.17.0 || >=13.2.0', () => {
-  test(`use downlevel ctor ast transformer internally in ESM mode`, () => {
-    const result = runJest('ast-transformers/downlevel-ctor', ['-c=jest-esm.config.js'], {
-      nodeOptions: '--experimental-vm-modules',
-    });
-
-    expect(result.exitCode).toBe(0);
-  });
-
-  test('use replace-resources ast transformer internally in ESM mode', () => {
-    const result = runJest('ast-transformers/replace-resources', ['-c=jest-esm.config.js'], {
+  test.each(INTERNAL_TRANSFORMER_NAMES)('use %s ast transformer in ESM mode', (astTransformerName) => {
+    const result = runJest(`ast-transformers/${astTransformerName}`, ['-c=jest-esm.config.js'], {
       nodeOptions: '--experimental-vm-modules',
     });
 

--- a/examples/test-app-v10/package.json
+++ b/examples/test-app-v10/package.json
@@ -5,9 +5,9 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "pretest": "jest --clearCache",
-    "test-cjs-uniso": "yarn pretest && jest -c=jest-cjs-uniso.config.js",
-    "test-cjs-iso": "yarn pretest && jest -c=jest-cjs-iso.config.js",
+    "pretest": "node ../../node_modules/jest-cli/bin/jest.js --clearCache",
+    "test-cjs-uniso": "yarn pretest && node ../../node_modules/jest-cli/bin/jest.js -c=jest-cjs-uniso.config.js",
+    "test-cjs-iso": "yarn pretest && node ../../node_modules/jest-cli/bin/jest.js -c=jest-cjs-iso.config.js",
     "test-esm-iso": "yarn pretest && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -c=jest-esm-iso.config.js",
     "test-esm-uniso": "yarn pretest && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -c=jest-esm-uniso.config.js"
   },

--- a/examples/test-app-v11/package.json
+++ b/examples/test-app-v11/package.json
@@ -5,9 +5,9 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "pretest": "jest --clearCache",
-    "test-cjs-uniso": "yarn pretest && jest -c=jest-cjs-uniso.config.js",
-    "test-cjs-iso": "yarn pretest && jest -c=jest-cjs-iso.config.js",
+    "pretest": "node ../../node_modules/jest-cli/bin/jest.js --clearCache",
+    "test-cjs-uniso": "yarn pretest && node ../../node_modules/jest-cli/bin/jest.js -c=jest-cjs-uniso.config.js",
+    "test-cjs-iso": "yarn pretest && node ../../node_modules/jest-cli/bin/jest.js -c=jest-cjs-iso.config.js",
     "test-esm-iso": "yarn pretest && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -c=jest-esm-iso.config.js",
     "test-esm-uniso": "yarn pretest && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -c=jest-esm-uniso.config.js"
   },

--- a/examples/test-app-v9/package.json
+++ b/examples/test-app-v9/package.json
@@ -5,9 +5,9 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "pretest": "jest --clearCache",
-    "test-cjs-uniso": "yarn pretest && jest -c=jest-cjs-uniso.config.js",
-    "test-cjs-iso": "yarn pretest && jest -c=jest-cjs-iso.config.js",
+    "pretest": "node ../../node_modules/jest-cli/bin/jest.js --clearCache",
+    "test-cjs-uniso": "yarn pretest && node ../../node_modules/jest-cli/bin/jest.js -c=jest-cjs-uniso.config.js",
+    "test-cjs-iso": "yarn pretest && node ../../node_modules/jest-cli/bin/jest.js -c=jest-cjs-iso.config.js",
     "test-esm-iso": "yarn pretest && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -c=jest-esm-iso.config.js",
     "test-esm-uniso": "yarn pretest && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -c=jest-esm-uniso.config.js"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
TypeScript provides a set of  pure  functions for producing syntax tree nodes. Since TypeScript 4.0 these methods have been deprecated in favor of the `factory` API.

See: https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-40

This PR replaces deprecated TypeScript method for `replace-resources` AST transformer. `downlevel-ctor` will be in another PR.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
