### PR TITLE
fix(presets): remove `moduleNameMapper` config

### DIFF
--- a/presets/index.js
+++ b/presets/index.js
@@ -12,12 +12,6 @@ const basePreset = {
     '^.+\\.(ts|js|html|css|sass|scss|less|styl)$': 'jest-preset-angular',
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json'],
-  moduleNameMapper: {
-    '^src/(.*)$': '<rootDir>/src/$1',
-    '^app/(.*)$': '<rootDir>/src/app/$1',
-    '^assets/(.*)$': '<rootDir>/src/assets/$1',
-    '^environments/(.*)$': '<rootDir>/src/environments/$1',
-  },
   snapshotSerializers,
 };
 
@@ -33,7 +27,6 @@ module.exports = {
       },
     },
     moduleNameMapper: {
-      ...basePreset.moduleNameMapper,
       tslib: '<rootDir>/node_modules/tslib/tslib.es6.js',
     },
     transformIgnorePatterns: ['node_modules/(?!tslib)'],

--- a/src/__tests__/__snapshots__/jest-preset.spec.ts.snap
+++ b/src/__tests__/__snapshots__/jest-preset.spec.ts.snap
@@ -14,12 +14,6 @@ Object {
     "js",
     "json",
   ],
-  "moduleNameMapper": Object {
-    "^app/(.*)$": "<rootDir>/src/app/$1",
-    "^assets/(.*)$": "<rootDir>/src/assets/$1",
-    "^environments/(.*)$": "<rootDir>/src/environments/$1",
-    "^src/(.*)$": "<rootDir>/src/$1",
-  },
   "snapshotSerializers": Array [
     "jest-preset-angular/build/serializers/html-comment",
     "jest-preset-angular/build/serializers/ng-snapshot",
@@ -51,10 +45,6 @@ Object {
     "json",
   ],
   "moduleNameMapper": Object {
-    "^app/(.*)$": "<rootDir>/src/app/$1",
-    "^assets/(.*)$": "<rootDir>/src/assets/$1",
-    "^environments/(.*)$": "<rootDir>/src/environments/$1",
-    "^src/(.*)$": "<rootDir>/src/$1",
     "tslib": "<rootDir>/node_modules/tslib/tslib.es6.js",
   },
   "snapshotSerializers": Array [

--- a/website/docs/getting-started/options.md
+++ b/website/docs/getting-started/options.md
@@ -25,12 +25,6 @@ module.exports = {
     '^.+\\.(ts|js|html)$': 'jest-preset-angular',
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json'],
-  moduleNameMapper: {
-    '^src/(.*)$': '<rootDir>/src/$1',
-    '^app/(.*)$': '<rootDir>/src/app/$1',
-    '^assets/(.*)$': '<rootDir>/src/assets/$1',
-    '^environments/(.*)$': '<rootDir>/src/environments/$1',
-  },
   snapshotSerializers,
 };
 ```

--- a/website/docs/guides/absolute-imports.md
+++ b/website/docs/guides/absolute-imports.md
@@ -3,36 +3,7 @@ id: absolute-imports
 title: Absolute Imports
 ---
 
-TypeScript supports absolute imports. The preset (starting from v3.0.0) by default understands absolute imports referring to `src`, `app`, `assets` and `environments` directory, so instead:
+If you wish to use TypeScript path mappings which are defined in `paths` of your tsconfig, make sure that you create the
+similar mapping for `moduleNameMapper` in Jest config.
 
-```ts
-import MyComponent from '../../src/app/my.component';
-import MyStuff from '../../src/testing/my.stuff';
-```
-
-you can use:
-
-```ts
-import MyComponent from 'app/my.component';
-import MyStuff from 'src/testing/my.stuff';
-```
-
-However, if your directory structure differ from that provided by `angular-cli` you can adjust `moduleNameMapper` in Jest config:
-
-```json5
-{
-  jest: {
-    moduleNameMapper: {
-      'app/(.*)': '<rootDir>/src/to/app/$1', // override default, why not
-      'testing/(.*)': '<rootDir>/app/testing/$1', // add new mapping
-    },
-  },
-}
-```
-
-:::important
-
-If you wish to use any absolute import paths which are defined in `paths` of your tsconfig, make sure that you create the
-similar mapping for `moduleNameMapper` in Jest config
-
-:::
+More information see `ts-jest` [paths mapping](https://kulshekhar.github.io/ts-jest/docs/getting-started/paths-mapping) configuration documentation


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Remove `moduleNameMapper` config from both presets, CJS and ESM

Closes #908 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
When generating a new project from Angular CLI, by default the `tsconfig.json` doesn't contain any path mappings hence removing `moduleNameMapper` from preset will make sure that the preset works in pair with `tsconfig.json`.

Ones who are relying on the value of `moduleNameMapper` from the preset should create their own `moduleNameMapper` config manually or via `ts-jest` util https://kulshekhar.github.io/ts-jest/docs/getting-started/paths-mapping

## Other information
**N.A.**
