### PR TITLE
docs: fix typo in preset name

### DIFF
--- a/website/docs/getting-started/presets.md
+++ b/website/docs/getting-started/presets.md
@@ -10,7 +10,7 @@ title: Presets
 | Preset name                                                        | Description                                                                                                                       |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `jest-preset-angular/presets/default`<br/>or `jest-preset-angular` | TypeScript, JavaScript and HTML files (`js`, `.ts`, `.html`) will be transformed by `jest-preset-angular` to **CommonJS** syntax. |
-| `jest-preset-angular/presets/default-esm`<br/>                     | TypeScript, JavaScript and HTML files (`js`, `.ts`, `.html`) will be transformed by `jest-preset-angular` to **ESM** syntax.      |
+| `jest-preset-angular/presets/defaults-esm`<br/>                    | TypeScript, JavaScript and HTML files (`js`, `.ts`, `.html`) will be transformed by `jest-preset-angular` to **ESM** syntax.      |
 
 ### Basic usage
 

--- a/website/docs/guides/esm-support.md
+++ b/website/docs/guides/esm-support.md
@@ -51,7 +51,7 @@ module.exports = {
 // jest.config.js
 module.exports = {
   // [...]
-  preset: 'jest-preset-angular/presets/default-esm',
+  preset: 'jest-preset-angular/presets/defaults-esm',
 };
 ```
 
@@ -60,7 +60,7 @@ module.exports = {
 {
   // [...]
   "jest": {
-    "preset": "jest-preset-angular/presets/default-esm"
+    "preset": "jest-preset-angular/presets/defaults-esm"
   }
 }
 ```

--- a/website/versioned_docs/version-9.x/getting-started/presets.md
+++ b/website/versioned_docs/version-9.x/getting-started/presets.md
@@ -10,7 +10,7 @@ title: Presets
 | Preset name                                                        | Description                                                                                                                       |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `jest-preset-angular/presets/default`<br/>or `jest-preset-angular` | TypeScript, JavaScript and HTML files (`js`, `.ts`, `.html`) will be transformed by `jest-preset-angular` to **CommonJS** syntax. |
-| `jest-preset-angular/presets/default-esm`<br/>                     | TypeScript, JavaScript and HTML files (`js`, `.ts`, `.html`) will be transformed by `jest-preset-angular` to **ESM** syntax.      |
+| `jest-preset-angular/presets/defaults-esm`<br/>                    | TypeScript, JavaScript and HTML files (`js`, `.ts`, `.html`) will be transformed by `jest-preset-angular` to **ESM** syntax.      |
 
 ### Basic usage
 

--- a/website/versioned_docs/version-9.x/guides/esm-support.md
+++ b/website/versioned_docs/version-9.x/guides/esm-support.md
@@ -51,7 +51,7 @@ module.exports = {
 // jest.config.js
 module.exports = {
   // [...]
-  preset: 'jest-preset-angular/presets/default-esm',
+  preset: 'jest-preset-angular/presets/defaults-esm',
 };
 ```
 
@@ -60,7 +60,7 @@ module.exports = {
 {
   // [...]
   "jest": {
-    "preset": "jest-preset-angular/presets/default-esm"
+    "preset": "jest-preset-angular/presets/defaults-esm"
   }
 }
 ```


### PR DESCRIPTION
There is a typo in the docs. It says `jest-preset-angular/presets/default-esm` everywhere, and it should say `jest-preset-angular/presets/defaults-esm` (note the **s** in **defaults**).

The tests are OK, though. It's just a problem in the docs.