### PR TITLE
since version 9.0.0 we need to use jest-preset-angular instead of ts-jest in the transform configuration

### DIFF
--- a/website/docs/guides/using-with-babel.md
+++ b/website/docs/guides/using-with-babel.md
@@ -30,7 +30,7 @@ _Note: do not use a `.babelrc` file otherwise the packages that you specify in t
 ```js
 module.exports = {
   transform: {
-    '^.+\\.(ts|html)$': 'ts-jest',
+    '^.+\\.(ts|html)$': 'jest-preset-angular',
     '^.+\\.js$': 'babel-jest',
   },
 };

--- a/website/versioned_docs/version-9.x/guides/using-with-babel.md
+++ b/website/versioned_docs/version-9.x/guides/using-with-babel.md
@@ -30,7 +30,7 @@ _Note: do not use a `.babelrc` file otherwise the packages that you specify in t
 ```js
 module.exports = {
   transform: {
-    '^.+\\.(ts|html)$': 'ts-jest',
+    '^.+\\.(ts|html)$': 'jest-preset-angular',
     '^.+\\.js$': 'babel-jest',
   },
 };


### PR DESCRIPTION
## Summary

I was running into issues using ts-jest in my transform configuration and ahnpnl pointed out that since version 9.0.0 we need to use jest-preset-angular instead. I noticed in the documentation here: https://thymikee.github.io/jest-preset-angular/docs/guides/using-with-babel that it states version 9.X at the top but still seems to be referencing ts-jest in the transform configuration. Seems like it should be updated to show jest-preset-angular instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No

## Other information

Simple documentation change.