### PR TITLE
fix(utils): throw error when cannot find `@angular/core` for `ngcc` util script

### DIFF
--- a/src/utils/ngcc-jest-processor.ts
+++ b/src/utils/ngcc-jest-processor.ts
@@ -7,7 +7,9 @@ import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 
 const IGNORE_ARGS = ['--clearCache', '--help', '--init', '--listTests', '--showConfig'];
-const canRunNgcc = !process.argv.find((arg) => IGNORE_ARGS.includes(arg));
+const nodeModuleDirPath = findNodeModulesDirectory(process.cwd());
+const canRunNgcc =
+  !process.argv.find((arg) => IGNORE_ARGS.includes(arg)) && existsSync(join(nodeModuleDirPath, '@angular', 'core'));
 function findNodeModulesDirectory(startPoint: string): string {
   let current = startPoint;
   while (dirname(current) !== current) {
@@ -36,12 +38,11 @@ if (canRunNgcc) {
     [
       require.resolve('@angular/compiler-cli/ngcc/main-ngcc.js'),
       '--source' /** basePath */,
-      findNodeModulesDirectory(process.cwd()),
+      nodeModuleDirPath,
       '--properties' /** propertiesToConsider */,
       /**
        * There are various properties: fesm2015, fesm5, es2015, esm2015, esm5, main, module, browser to choose from.
-       * Currently Jest requires `commonjs` so we only need to ask `ngcc` to produce `umd` outputs. Later when switching
-       * to ESM, we can change to different properties to produce ESM outputs.
+       * Normally, Jest requires `umd`. If running Jest in ESM mode, Jest will require both `umd` + `esm2015`.
        */
       ...['es2015', 'main'],
       '--first-only' /** compileAllFormats */,
@@ -57,4 +58,8 @@ if (canRunNgcc) {
 
     throw new Error(`${errorMessage} NGCC failed ${errorMessage ? ', see above' : ''}.`);
   }
+} else {
+  throw new Error(
+    `Cannot locate the '@angular/core' directory. Please make sure you are running 'ngcc-jest-processor.js' from root level of your project`,
+  );
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Add an extra check on the existence of `@angular/core` package to `ngcc-jest-processor` util script and throw error when `@angular/core` is not found. This will help users to know if `ngcc` is invoked correctly or not.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
**N.A.**

## Other information

