### PR TITLE
feat: add support for svg templates

### DIFF
--- a/presets/index.js
+++ b/presets/index.js
@@ -4,12 +4,12 @@ const basePreset = {
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.html$',
+      stringifyContentPathRegex: '\\.(html|svg)$',
     },
   },
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|js|html|svg)$': 'jest-preset-angular',
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json'],
   snapshotSerializers,

--- a/src/__tests__/__mocks__/icon.component.svg
+++ b/src/__tests__/__mocks__/icon.component.svg
@@ -1,0 +1,6 @@
+<svg>
+  <g>
+    <rect x="0" y="0" width="100" height="100" [attr.fill]="fillColor" />
+    <text x="120" y="50">click the rectangle to change the fill color</text>
+  </g>
+</svg>

--- a/src/__tests__/__mocks__/icon.component.ts
+++ b/src/__tests__/__mocks__/icon.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-icon',
+  templateUrl: './icon.component.svg',
+})
+export class IconComponent {
+  fillColor = 'rgb(255, 0, 0)';
+}

--- a/src/__tests__/__snapshots__/jest-preset.spec.ts.snap
+++ b/src/__tests__/__snapshots__/jest-preset.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`Jest presets should return the correct jest config 1`] = `
 Object {
   "globals": Object {
     "ts-jest": Object {
-      "stringifyContentPathRegex": "\\\\.html$",
+      "stringifyContentPathRegex": "\\\\.(html|svg)$",
       "tsconfig": "<rootDir>/tsconfig.spec.json",
     },
   },
@@ -21,7 +21,7 @@ Object {
   ],
   "testEnvironment": "jsdom",
   "transform": Object {
-    "^.+\\\\.(ts|js|html)$": "jest-preset-angular",
+    "^.+\\\\.(ts|js|html|svg)$": "jest-preset-angular",
   },
 }
 `;
@@ -33,7 +33,7 @@ Object {
   ],
   "globals": Object {
     "ts-jest": Object {
-      "stringifyContentPathRegex": "\\\\.html$",
+      "stringifyContentPathRegex": "\\\\.(html|svg)$",
       "tsconfig": "<rootDir>/tsconfig.spec.json",
       "useESM": true,
     },
@@ -54,7 +54,7 @@ Object {
   ],
   "testEnvironment": "jsdom",
   "transform": Object {
-    "^.+\\\\.(ts|js|html)$": "jest-preset-angular",
+    "^.+\\\\.(ts|js|html|svg)$": "jest-preset-angular",
   },
   "transformIgnorePatterns": Array [
     "node_modules/(?!tslib)",

--- a/src/__tests__/__snapshots__/replace-resources.spec.ts.snap
+++ b/src/__tests__/__snapshots__/replace-resources.spec.ts.snap
@@ -78,3 +78,43 @@ FooComponent = __decorate([
 export { FooComponent };
 //# "
 `;
+
+exports[`should keep styles/template and transform styleUrls/templateUrl to proper syntax for CommonJS/ESM: icon.component.ts-with-esm-false 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.IconComponent = void 0;
+const tslib_1 = require(\\"tslib\\");
+const core_1 = require(\\"@angular/core\\");
+let IconComponent = class IconComponent {
+    constructor() {
+        this.fillColor = 'rgb(255, 0, 0)';
+    }
+};
+IconComponent = tslib_1.__decorate([
+    core_1.Component({
+        selector: 'app-icon',
+        template: require(\\"./icon.component.svg\\"),
+    })
+], IconComponent);
+exports.IconComponent = IconComponent;
+//# "
+`;
+
+exports[`should keep styles/template and transform styleUrls/templateUrl to proper syntax for CommonJS/ESM: icon.component.ts-with-esm-true 1`] = `
+"import { __decorate } from \\"tslib\\";
+import __NG_CLI_RESOURCE__0 from \\"./icon.component.svg\\";
+import { Component } from '@angular/core';
+let IconComponent = class IconComponent {
+    constructor() {
+        this.fillColor = 'rgb(255, 0, 0)';
+    }
+};
+IconComponent = __decorate([
+    Component({
+        selector: 'app-icon',
+        template: __NG_CLI_RESOURCE__0,
+    })
+], IconComponent);
+export { IconComponent };
+//# "
+`;

--- a/src/__tests__/replace-resources.spec.ts
+++ b/src/__tests__/replace-resources.spec.ts
@@ -12,10 +12,13 @@ import { mockFolder } from './__helpers__/test-helpers';
 
 const fileName1 = 'app.component.ts';
 const fileName2 = 'foo.component.ts';
+const fileName3 = 'icon.component.ts';
 const filePath1 = join(mockFolder, 'app.component.ts');
 const filePath2 = join(mockFolder, 'foo.component.ts');
+const filePath3 = join(mockFolder, 'icon.component.ts');
 const fileContent1 = readFileSync(filePath1, 'utf-8');
 const fileContent2 = readFileSync(filePath2, 'utf-8');
+const fileContent3 = readFileSync(filePath3, 'utf-8');
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const baseJestCfg = {
   ...jestCfgStub,
@@ -70,6 +73,16 @@ test.each([true, false])(
 
     expect(output2.substring(0, output2.indexOf(SOURCE_MAPPING_PREFIX))).toMatchSnapshot(
       `${fileName2}-with-esm-${useESM}`,
+    );
+
+    const output3 = compiler.getCompiledOutput(fileContent3, filePath3, {
+      watchMode: false,
+      supportsStaticESM: useESM,
+      depGraphs: new Map(),
+    });
+
+    expect(output3.substring(0, output3.indexOf(SOURCE_MAPPING_PREFIX))).toMatchSnapshot(
+      `${fileName3}-with-esm-${useESM}`,
     );
   },
 );

--- a/website/docs/getting-started/options.md
+++ b/website/docs/getting-started/options.md
@@ -33,12 +33,12 @@ module.exports = {
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.html$',
+      stringifyContentPathRegex: '\\.(html|svg)$',
     },
   },
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|js|html|svg)$': 'jest-preset-angular',
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json'],
   snapshotSerializers,

--- a/website/versioned_docs/version-9.x/getting-started/options.md
+++ b/website/versioned_docs/version-9.x/getting-started/options.md
@@ -33,12 +33,12 @@ module.exports = {
   globals: {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.html$',
+      stringifyContentPathRegex: '\\.(html|svg)$',
     },
   },
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|js|html|svg)$': 'jest-preset-angular',
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json'],
   snapshotSerializers,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

See issue: https://github.com/thymikee/jest-preset-angular/issues/1055


## Test plan

Honnestly, I am not quite sure hom to test that feature using jest.

I can add a svg file in the examples but I am not sure it would count as proper testing.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

