### PR TITLE
refactor: bring back checks on `undefined`/`null` for `no-ng-attributes` serializer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   moduleNameMapper: {
     '@angular/compiler-cli/ngcc': '<rootDir>/node_modules/@angular/compiler-cli/bundles/ngcc/main-ngcc.js',
   },
+  testEnvironment: 'jsdom',
   modulePathIgnorePatterns: ['examples/.*', 'website/.*'],
   resolver: '<rootDir>/build/resolvers/ng-jest-resolver',
   snapshotSerializers: [require.resolve('jest-snapshot-serializer-raw')],

--- a/src/__tests__/ng-snapshot.spec.ts
+++ b/src/__tests__/ng-snapshot.spec.ts
@@ -1,6 +1,6 @@
 import ngSnapshot from '../serializers/ng-snapshot';
 
-describe('ng-snapshot', () => {
+describe('ng-snapshot snapshot serializer', () => {
   test('should return true when matching the condition', () => {
     expect(ngSnapshot.test({ componentRef: 'foo' })).toBe(true);
   });

--- a/src/__tests__/no-ng-attributes.spec.ts
+++ b/src/__tests__/no-ng-attributes.spec.ts
@@ -1,0 +1,32 @@
+import noNgAttr from '../serializers/no-ng-attributes';
+
+describe('no-ng-attributes snapshot serializer', () => {
+  test('should return true when matching the condition with attributes to remove', () => {
+    const validElement = document.createElement('DIV');
+    ['ng-reflect', '_nghost', '_ngcontent', 'ng-version'].forEach((attrToRemove) => {
+      validElement.setAttribute(attrToRemove, 'foo');
+    });
+
+    expect(noNgAttr.test(validElement)).toBe(true);
+
+    validElement.remove();
+  });
+
+  test('should return true when matching the condition with attributes to clean', () => {
+    const validElement = document.createElement('SECTION');
+    ['class', 'id', 'for', 'aria-owns', 'aria-labelledby', 'aria-controls'].forEach((attrToClean) => {
+      validElement.setAttribute(attrToClean, 'foo');
+    });
+
+    expect(noNgAttr.test(validElement)).toBe(true);
+
+    validElement.remove();
+  });
+
+  test.each([undefined, null, 1, document.createElement('INPUT')])(
+    'should return false when not matching the condition',
+    (val) => {
+      expect(noNgAttr.test(val)).toBe(false);
+    },
+  );
+});

--- a/src/serializers/no-ng-attributes.ts
+++ b/src/serializers/no-ng-attributes.ts
@@ -47,11 +47,11 @@ const serialize = (node: Element, ...rest: any): string => {
 };
 
 const serializeTestFn = (val: Element): boolean =>
-  val.attributes &&
+  !!val.attributes &&
   Object.values(val.attributes).some(
     (attribute: Attr) => hasAttributesToRemove(attribute) || hasAttributesToClean(attribute),
   );
-const test = (val: Element): boolean => jestDOMElementSerializer.test(val) && serializeTestFn(val);
+const test = (val: unknown): boolean => !!val && jestDOMElementSerializer.test(val) && serializeTestFn(val as Element);
 
 export = {
   serialize,


### PR DESCRIPTION
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit test

Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->


## Other information
**N.A.**
