### PR TITLE
build(devs-infra): configure `dependabot` to ignore updating some deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: 'esbuild'
+      - dependency-name: 'jest*'
+      - dependency-name: '@jest*'
+      - dependency-name: '@angular*'
+      - dependency-name: 'pretty-format'
     commit-message:
       prefix: 'build(deps-dev)'
     labels:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Ignore all deps related to Jest and Angular from dependabot updates. These deps need to be manually updated. See reference https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
dependabot should not check update for these deps anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**