### PR TITLE
test(unit): update unit tests in the example apps

### DIFF
--- a/examples/example-app-v10/src/app/app.component.spec.ts
+++ b/examples/example-app-v10/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {

--- a/examples/example-app-v10/src/app/app.component.spec.ts
+++ b/examples/example-app-v10/src/app/app.component.spec.ts
@@ -1,13 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-v10/src/app/app.component.spec.ts
+++ b/examples/example-app-v10/src/app/app.component.spec.ts
@@ -1,43 +1,50 @@
-import { TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { environment } from '../environments/environment';
-
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './configs/environment.config';
+import { AppEnvironment, APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useValue: environment,
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'example-app-v10'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('example-app-v10');
+    expect(component.title).toEqual('example-app-v10');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('example-app-v10 app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span').textContent).toContain(
+      'example-app-v10 app is running!',
+    );
   });
 });

--- a/examples/example-app-v10/src/app/app.module.ts
+++ b/examples/example-app-v10/src/app/app.module.ts
@@ -1,13 +1,21 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-v10/src/app/app.module.ts
+++ b/examples/example-app-v10/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { environment } from '../environments/environment';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 
 @NgModule({
   declarations: [AppComponent],

--- a/examples/example-app-v10/src/app/configs/environment.config.ts
+++ b/examples/example-app-v10/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v10/src/app/configs/environment.config.ts
+++ b/examples/example-app-v10/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-v10/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-v10/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-v10/src/app/guards/route.guard.ts
+++ b/examples/example-app-v10/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-v10/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v10/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v10/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v10/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v10/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v10/src/app/services/foo.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
@@ -11,13 +10,13 @@ describe('FooService', () => {
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-v10/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v10/src/app/services/foo.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-v10/src/app/services/foo.service.ts
+++ b/examples/example-app-v10/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-v10/src/app/services/foo.service.ts
+++ b/examples/example-app-v10/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-v10/src/environments/environment.prod.ts
+++ b/examples/example-app-v10/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v10/src/environments/environment.prod.ts
+++ b/examples/example-app-v10/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v10/src/environments/environment.ts
+++ b/examples/example-app-v10/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build ---prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v10/src/environments/environment.ts
+++ b/examples/example-app-v10/src/environments/environment.ts
@@ -2,9 +2,9 @@
 // `ng build ---prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v10/tsconfig-esm.spec.json
+++ b/examples/example-app-v10/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-v10/tsconfig-esm.spec.json
+++ b/examples/example-app-v10/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/examples/example-app-v10/tsconfig.json
+++ b/examples/example-app-v10/tsconfig.json
@@ -12,10 +12,7 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "es2020",
-    "lib": [
-      "es2018",
-      "dom"
-    ],
+    "lib": ["es2018", "dom"],
     "paths": {
       "@services/*": ["src/app/services/*"]
     }

--- a/examples/example-app-v11/src/app/app.component.spec.ts
+++ b/examples/example-app-v11/src/app/app.component.spec.ts
@@ -1,13 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-v11/src/app/app.component.spec.ts
+++ b/examples/example-app-v11/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { AppComponent } from './app.component';
@@ -7,36 +8,44 @@ import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useFactory: () => new AppEnvironment(),
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'example-app-v11'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('example-app-v11');
+    expect(component.title).toEqual('example-app-v11');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('example-app-v11 app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span').textContent).toContain(
+      'example-app-v11 app is running!',
+    );
   });
 });

--- a/examples/example-app-v11/src/app/app.component.spec.ts
+++ b/examples/example-app-v11/src/app/app.component.spec.ts
@@ -1,10 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { environment } from '../environments/environment';
-
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { AppEnvironment } from './configs/environment.config';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
@@ -16,7 +15,7 @@ describe('AppComponent', () => {
         FooService,
         {
           provide: APP_ENVIRONMENT,
-          useValue: environment,
+          useFactory: () => new AppEnvironment(),
         },
       ],
     }).compileComponents();

--- a/examples/example-app-v11/src/app/app.module.ts
+++ b/examples/example-app-v11/src/app/app.module.ts
@@ -1,13 +1,21 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-v11/src/app/app.module.ts
+++ b/examples/example-app-v11/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { environment } from '../environments/environment';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 
 @NgModule({
   declarations: [AppComponent],

--- a/examples/example-app-v11/src/app/configs/environment.config.ts
+++ b/examples/example-app-v11/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v11/src/app/configs/environment.config.ts
+++ b/examples/example-app-v11/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-v11/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-v11/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-v11/src/app/guards/route.guard.ts
+++ b/examples/example-app-v11/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-v11/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v11/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v11/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v11/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v11/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v11/src/app/services/foo.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
@@ -11,13 +10,13 @@ describe('FooService', () => {
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-v11/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v11/src/app/services/foo.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-v11/src/app/services/foo.service.ts
+++ b/examples/example-app-v11/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-v11/src/app/services/foo.service.ts
+++ b/examples/example-app-v11/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-v11/src/environments/environment.prod.ts
+++ b/examples/example-app-v11/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v11/src/environments/environment.prod.ts
+++ b/examples/example-app-v11/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v11/src/environments/environment.ts
+++ b/examples/example-app-v11/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v11/src/environments/environment.ts
+++ b/examples/example-app-v11/src/environments/environment.ts
@@ -2,9 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v11/tsconfig-esm.spec.json
+++ b/examples/example-app-v11/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-v11/tsconfig-esm.spec.json
+++ b/examples/example-app-v11/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/app.component.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/app.component.spec.ts
@@ -1,41 +1,48 @@
-import { TestBed } from '@angular/core/testing';
-
-import { environment } from '../environments/environment';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './configs/environment.config';
+import { AppEnvironment, APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useValue: environment,
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'app1'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('app1');
+    expect(component.title).toEqual('app1');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('app1 app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span')?.textContent).toContain(
+      'app1 app is running!',
+    );
   });
 });

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/app.component.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/app.component.spec.ts
@@ -1,11 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/app.component.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/app.module.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 
 @NgModule({
   declarations: [AppComponent],

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/app.module.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/app.module.ts
@@ -1,12 +1,20 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/configs/environment.config.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/configs/environment.config.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/guards/route.guard.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
@@ -11,13 +10,13 @@ describe('FooService', () => {
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.prod.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.prod.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.ts
+++ b/examples/example-app-v12-monorepo/projects/app1/src/environments/environment.ts
@@ -2,9 +2,9 @@
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v12-monorepo/projects/app1/tsconfig-esm.spec.json
+++ b/examples/example-app-v12-monorepo/projects/app1/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-v12-monorepo/projects/app1/tsconfig-esm.spec.json
+++ b/examples/example-app-v12-monorepo/projects/app1/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/app.component.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/app.component.spec.ts
@@ -1,11 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/app.component.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/app.component.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/app.component.spec.ts
@@ -1,41 +1,48 @@
-import { TestBed } from '@angular/core/testing';
-
-import { environment } from '../environments/environment';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './configs/environment.config';
+import { AppEnvironment, APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useValue: environment,
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'app2'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('app2');
+    expect(component.title).toEqual('app2');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('app2 app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span')?.textContent).toContain(
+      'app2 app is running!',
+    );
   });
 });

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/app.module.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 
 @NgModule({
   declarations: [AppComponent],

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/app.module.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/app.module.ts
@@ -1,12 +1,20 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/configs/environment.config.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/configs/environment.config.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/guards/route.guard.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
@@ -11,13 +10,13 @@ describe('FooService', () => {
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-v12-monorepo/projects/app2/src/environments/environment.prod.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { AppEnvironment } from '../app/configs/environment.config';
+
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v12-monorepo/projects/app2/src/environments/environment.ts
+++ b/examples/example-app-v12-monorepo/projects/app2/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { AppEnvironment } from '../app/configs/environment.config';
+
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v12-monorepo/projects/app2/tsconfig-esm.spec.json
+++ b/examples/example-app-v12-monorepo/projects/app2/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-v12-monorepo/projects/app2/tsconfig-esm.spec.json
+++ b/examples/example-app-v12-monorepo/projects/app2/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/examples/example-app-v12/src/app/app.component.spec.ts
+++ b/examples/example-app-v12/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {

--- a/examples/example-app-v12/src/app/app.component.spec.ts
+++ b/examples/example-app-v12/src/app/app.component.spec.ts
@@ -1,43 +1,50 @@
-import { TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { environment } from '../environments/environment';
-
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './configs/environment.config';
+import { AppEnvironment, APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useValue: environment,
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'example-app-v12'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('example-app-v12');
+    expect(component.title).toEqual('example-app-v12');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('example-app-v12 app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span').textContent).toContain(
+      'example-app-v12 app is running!',
+    );
   });
 });

--- a/examples/example-app-v12/src/app/app.component.spec.ts
+++ b/examples/example-app-v12/src/app/app.component.spec.ts
@@ -1,13 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-v12/src/app/app.module.ts
+++ b/examples/example-app-v12/src/app/app.module.ts
@@ -1,13 +1,21 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-v12/src/app/app.module.ts
+++ b/examples/example-app-v12/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { environment } from '../environments/environment';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 
 @NgModule({
   declarations: [AppComponent],

--- a/examples/example-app-v12/src/app/configs/environment.config.ts
+++ b/examples/example-app-v12/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12/src/app/configs/environment.config.ts
+++ b/examples/example-app-v12/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-v12/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-v12/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-v12/src/app/guards/route.guard.ts
+++ b/examples/example-app-v12/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-v12/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v12/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v12/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v12/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v12/src/app/services/foo.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
@@ -11,13 +10,13 @@ describe('FooService', () => {
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-v12/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v12/src/app/services/foo.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-v12/src/app/services/foo.service.ts
+++ b/examples/example-app-v12/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-v12/src/app/services/foo.service.ts
+++ b/examples/example-app-v12/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-v12/src/environments/environment.prod.ts
+++ b/examples/example-app-v12/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v12/src/environments/environment.prod.ts
+++ b/examples/example-app-v12/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v12/src/environments/environment.ts
+++ b/examples/example-app-v12/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v12/src/environments/environment.ts
+++ b/examples/example-app-v12/src/environments/environment.ts
@@ -2,9 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v12/tsconfig-esm.spec.json
+++ b/examples/example-app-v12/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-v12/tsconfig-esm.spec.json
+++ b/examples/example-app-v12/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/examples/example-app-v13/src/app/app.component.spec.ts
+++ b/examples/example-app-v13/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {

--- a/examples/example-app-v13/src/app/app.component.spec.ts
+++ b/examples/example-app-v13/src/app/app.component.spec.ts
@@ -1,43 +1,50 @@
-import { TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { environment } from '../environments/environment';
-
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './configs/environment.config';
+import { AppEnvironment, APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useValue: environment,
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'example-app-v13'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('example-app-v13');
+    expect(component.title).toEqual('example-app-v13');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain('example-app-v13 app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span')?.textContent).toContain(
+      'example-app-v13 app is running!',
+    );
   });
 });

--- a/examples/example-app-v13/src/app/app.component.spec.ts
+++ b/examples/example-app-v13/src/app/app.component.spec.ts
@@ -1,13 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-v13/src/app/app.module.ts
+++ b/examples/example-app-v13/src/app/app.module.ts
@@ -1,13 +1,21 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-v13/src/app/configs/environment.config.ts
+++ b/examples/example-app-v13/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v13/src/app/configs/environment.config.ts
+++ b/examples/example-app-v13/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-v13/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-v13/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-v13/src/app/guards/route.guard.ts
+++ b/examples/example-app-v13/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-v13/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v13/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v13/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-v13/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-v13/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v13/src/app/services/foo.service.spec.ts
@@ -1,25 +1,22 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
 describe('FooService', () => {
   const testBedMetadata: TestModuleMetadata = {
-    imports: [HttpClientTestingModule],
     providers: [
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-v13/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-v13/src/app/services/foo.service.spec.ts
@@ -1,0 +1,48 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    imports: [HttpClientTestingModule],
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-v13/src/app/services/foo.service.ts
+++ b/examples/example-app-v13/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-v13/src/app/services/foo.service.ts
+++ b/examples/example-app-v13/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-v13/src/environments/environment.prod.ts
+++ b/examples/example-app-v13/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v13/src/environments/environment.prod.ts
+++ b/examples/example-app-v13/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: true,
 };

--- a/examples/example-app-v13/src/environments/environment.ts
+++ b/examples/example-app-v13/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v13/src/environments/environment.ts
+++ b/examples/example-app-v13/src/environments/environment.ts
@@ -2,9 +2,9 @@
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-v13/tsconfig-esm.spec.json
+++ b/examples/example-app-v13/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-v13/tsconfig-esm.spec.json
+++ b/examples/example-app-v13/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.component.spec.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.component.spec.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.component.spec.ts
@@ -1,13 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { environment } from '../environments/environment';
+
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule],
       declarations: [AppComponent],
+      providers: [
+        FooService,
+        {
+          provide: APP_ENVIRONMENT,
+          useValue: environment,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.component.spec.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.component.spec.ts
@@ -1,43 +1,50 @@
-import { TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { environment } from '../environments/environment';
-
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './configs/environment.config';
+import { AppEnvironment, APP_ENVIRONMENT } from './configs/environment.config';
 import { FooService } from './services/foo.service';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent],
-      providers: [
-        FooService,
-        {
-          provide: APP_ENVIRONMENT,
-          useValue: environment,
-        },
-      ],
-    }).compileComponents();
-  });
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let debugEl: DebugElement;
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        declarations: [AppComponent],
+        providers: [
+          FooService,
+          {
+            provide: APP_ENVIRONMENT,
+            useFactory: () => new AppEnvironment(),
+          },
+        ],
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(AppComponent);
+          component = fixture.componentInstance;
+          debugEl = fixture.debugElement;
+          fixture.detectChanges();
+        });
+    }),
+  );
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
   });
 
   it(`should have as title 'example-app-v12'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('example-app-yarn-workspace');
+    expect(component.title).toEqual('example-app-yarn-workspace');
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('example-app-yarn-workspace app is running!');
+    expect((<HTMLElement>debugEl.nativeElement).querySelector('.content span').textContent).toContain(
+      'example-app-yarn-workspace app is running!',
+    );
   });
 });

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.module.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.module.ts
@@ -1,13 +1,21 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { environment } from '../environments/environment';
+
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { APP_ENVIRONMENT } from './interfaces/environment.interface';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  providers: [
+    {
+      provide: APP_ENVIRONMENT,
+      useValue: environment,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.module.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { environment } from '../environments/environment';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { APP_ENVIRONMENT } from './interfaces/environment.interface';
+import { APP_ENVIRONMENT } from './configs/environment.config';
 
 @NgModule({
   declarations: [AppComponent],

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/configs/environment.config.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/configs/environment.config.ts
@@ -1,0 +1,20 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ */
+export class AppEnvironment {
+  constructor(input?: Partial<AppEnvironment>) {
+    if (typeof input !== 'undefined') {
+      const keys = Object.keys(input);
+      for (const key of keys) {
+        const k = <keyof AppEnvironment>key;
+        this[k] = input[k] ?? false;
+      }
+    }
+  }
+
+  public production = false;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<AppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/configs/environment.config.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/configs/environment.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * @nore Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
+ * @note Using TypeScript interface instead of class breaks jest esm tests with isolated modules on.
  */
 export class AppEnvironment {
   constructor(input?: Partial<AppEnvironment>) {

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/guards/route.guard.spec.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/guards/route.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { tap } from 'rxjs/operators';
+
+import { RouteGuard } from './route.guard';
+
+describe('RouteGuard', () => {
+  let guard: RouteGuard;
+  let router: Router;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            {
+              path: '',
+              children: [],
+            },
+          ]),
+        ],
+        providers: [RouteGuard],
+      })
+        .compileComponents()
+        .then(() => {
+          guard = TestBed.inject(RouteGuard);
+          router = TestBed.inject(Router);
+        });
+    }),
+  );
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it(
+    'should activate correctly',
+    waitForAsync(() => {
+      const routeSnapShot = new ActivatedRouteSnapshot();
+      const stateSnapshot = router.routerState.snapshot;
+      guard
+        .canActivate(routeSnapShot, stateSnapshot)
+        .pipe(
+          tap((result) => {
+            expect(result).toEqual(router.createUrlTree([stateSnapshot.url]));
+          }),
+        )
+        .subscribe();
+    }),
+  );
+});

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/guards/route.guard.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/guards/route.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RouteGuard implements CanActivate {
+  constructor(private readonly router: Router) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return of(state.url).pipe(map((url) => this.router.createUrlTree([url])));
+  }
+}

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/interfaces/environment.interface.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export interface IAppEnvironment {
+  production: boolean;
+}
+
+export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/interfaces/environment.interface.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/interfaces/environment.interface.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export interface IAppEnvironment {
-  production: boolean;
-}
-
-export const APP_ENVIRONMENT = new InjectionToken<IAppEnvironment>('APP_ENVIRONMENT');

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
 
-import { environment } from '../../environments/environment';
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 import { FooService } from './foo.service';
 
@@ -11,13 +10,13 @@ describe('FooService', () => {
       FooService,
       {
         provide: APP_ENVIRONMENT,
-        useValue: environment,
+        useFactory: () => new AppEnvironment(),
       },
     ],
   };
 
   let service: FooService;
-  let env: IAppEnvironment;
+  let env: AppEnvironment;
 
   beforeEach(
     waitForAsync(() => {

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.spec.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+
+import { environment } from '../../environments/environment';
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+
+import { FooService } from './foo.service';
+
+describe('FooService', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    providers: [
+      FooService,
+      {
+        provide: APP_ENVIRONMENT,
+        useValue: environment,
+      },
+    ],
+  };
+
+  let service: FooService;
+  let env: IAppEnvironment;
+
+  beforeEach(
+    waitForAsync(() => {
+      void TestBed.configureTestingModule(testBedMetadata)
+        .compileComponents()
+        .then(() => {
+          service = TestBed.inject(FooService);
+          env = TestBed.inject(APP_ENVIRONMENT);
+        });
+    }),
+  );
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getFoo should return "foo" if env is production', () => {
+    env.production = true;
+    expect(service.getFoo()).toEqual('foo');
+  });
+
+  it('getFoo should return "bar" if env is not production', () => {
+    env.production = false;
+    expect(service.getFoo()).toEqual('bar');
+  });
+});

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.ts
@@ -1,10 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+
+import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+
   getFoo(): string {
-    return 'foo';
+    return this.env.production ? 'foo' : 'bar';
   }
 }

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/app/services/foo.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 
-import { APP_ENVIRONMENT, IAppEnvironment } from '../interfaces/environment.interface';
+import { APP_ENVIRONMENT, AppEnvironment } from '../configs/environment.config';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FooService {
-  constructor(@Inject(APP_ENVIRONMENT) private readonly env: IAppEnvironment) {}
+  constructor(@Inject(APP_ENVIRONMENT) private readonly env: AppEnvironment) {}
 
   getFoo(): string {
     return this.env.production ? 'foo' : 'bar';

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.prod.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: true,
 };

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.prod.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: true,
 };

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IAppEnvironment } from '../app/interfaces/environment.interface';
+
+export const environment: IAppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.ts
+++ b/examples/example-app-yarn-workspace/packages/angular-app/src/environments/environment.ts
@@ -2,9 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-import { IAppEnvironment } from '../app/interfaces/environment.interface';
+import { AppEnvironment } from '../app/configs/environment.config';
 
-export const environment: IAppEnvironment = {
+export const environment: AppEnvironment = {
   production: false,
 };
 

--- a/examples/example-app-yarn-workspace/packages/angular-app/tsconfig-esm.spec.json
+++ b/examples/example-app-yarn-workspace/packages/angular-app/tsconfig-esm.spec.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/environments"]
 }

--- a/examples/example-app-yarn-workspace/packages/angular-app/tsconfig-esm.spec.json
+++ b/examples/example-app-yarn-workspace/packages/angular-app/tsconfig-esm.spec.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.spec.json",
   "compilerOptions": {
     "module": "ESNext"
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- [X] add more unit tests to existing example applications as requested in [#110](https://github.com/thymikee/jest-preset-angular/issues/110);
- [X] add `include` property to tsconfigs for esm specs; without it esm specs are failing, can't find exports;

## Test plan

All unit tests should be green.
I tested locally everything (including `yarn test-esm`) except Angular v13 tests.
I could not make Angular v13 unit tests work locally, but I am pretty sure the specs that were added should pass.

## Does this PR introduce a breaking change?

- [X] No

## Other information
