### PR TITLE
fix(presets): use jest types for exposed default options

### DIFF
--- a/presets/index.d.ts
+++ b/presets/index.d.ts
@@ -1,7 +1,7 @@
-import type { TsJestPresets } from 'ts-jest/dist/types';
+import type { Config } from '@jest/types';
 
 declare const _default: {
-  defaults: TsJestPresets;
-  defaultsESM: TsJestPresets;
+  defaults: Config.InitialOptions;
+  defaultsESM: Config.InitialOptions;
 };
 export = _default;

--- a/presets/index.d.ts
+++ b/presets/index.d.ts
@@ -1,7 +1,7 @@
-import type { Config } from '@jest/types';
+import type { InitialOptionsTsJest } from 'ts-jest/dist/types';
 
 declare const _default: {
-  defaults: Config.InitialOptions;
-  defaultsESM: Config.InitialOptions;
+  defaults: InitialOptionsTsJest;
+  defaultsESM: InitialOptionsTsJest;
 };
 export = _default;


### PR DESCRIPTION
## Summary

The type `TsJestPresets` is only a subset of Jest's `InitialOptions`-type:

https://github.com/kulshekhar/ts-jest/blob/c7ba4593ffdcc2bc81c1193863ab2941c3376976/src/types.ts#L46-L49

When e.g. accessing property `global` (as shown in the [documentation](https://thymikee.github.io/jest-preset-angular/docs/getting-started/presets/#advanced)) TS will complain, because it is not Part of `TsJestPresets`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
