### PR TITLE
perf(transformer): cache useNativeEsbuild result

### DIFF
--- a/src/ng-jest-transformer.ts
+++ b/src/ng-jest-transformer.ts
@@ -14,7 +14,7 @@ import { NgJestConfig } from './config/ng-jest-config';
 // Cache the result between multiple transformer instances
 // to avoid spawning multiple processes (which can have a major
 // performance impact when used with multiple projects).
-let useNativeEsbuild: boolean | null = null;
+let useNativeEsbuild: boolean;
 
 export class NgJestTransformer extends TsJestTransformer {
   #ngJestLogger: Logger;
@@ -32,7 +32,7 @@ export class NgJestTransformer extends TsJestTransformer {
       targets: process.env.NG_JEST_LOG ?? undefined,
     });
 
-    if (useNativeEsbuild === null) {
+    if (useNativeEsbuild === undefined) {
       try {
         const esbuildCheckPath = require.resolve('@angular-devkit/build-angular/esbuild-check.js');
         const { status, error } = spawnSync(process.execPath, [esbuildCheckPath]);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Since the result will be the same for all transformer instances we can cache the result, thus avoiding resolving and spawning redundant processes.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

For a test harness with ~3800 tests grouped in ~110 projects this translates to a reduction in running time of ~20s. Attaching a screenshot of the profile that shows how instantiation takes ~20s.

![image](https://user-images.githubusercontent.com/2109702/152513040-d156e8c9-8251-4bb2-8177-512b07bf7bf4.png)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The existing tests are passing (`npm test`). Our existing test harness runs without any issues with this patch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
