### PR TITLE
perf(transformer): only construct configSet when necessary

### DIFF
--- a/src/ng-jest-transformer.ts
+++ b/src/ng-jest-transformer.ts
@@ -50,7 +50,6 @@ export class NgJestTransformer extends TsJestTransformer {
     filePath: Config.Path,
     transformOptions: TransformOptionsTsJest,
   ): TransformedSource | string {
-    const configSet = this._createConfigSet(transformOptions.config);
     /**
      * TypeScript < 4.5 doesn't support compiling `.mjs` file by default when running `tsc` which throws error. Also we
      * transform `js` files from `node_modules` assuming that `node_modules` contains compiled files to speed up compilation.
@@ -63,6 +62,7 @@ export class NgJestTransformer extends TsJestTransformer {
     ) {
       this.#ngJestLogger.debug({ filePath }, 'process with esbuild');
 
+      const configSet = this._createConfigSet(transformOptions.config);
       const compilerOpts = configSet.parsedTsConfig.options;
       const { code, map } = this.#esbuildImpl.transformSync(fileContent, {
         loader: 'js',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

The constructor of `ConfigSet` is quite expensive (path concatenations, merging configurations, reading from disk...). It should only be triggered when needed.

## Test plan

`npm test` is passing. Our test harness runs without any issues with this patch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
