### PR TITLE
perf(transformer): leverage the ts-jest config set cache

### DIFF
--- a/src/ng-jest-transformer.spec.ts
+++ b/src/ng-jest-transformer.spec.ts
@@ -105,6 +105,7 @@ describe('NgJestTransformer', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const transformSyncMock = transformSync as unknown as jest.MockInstance<unknown, any>;
     const transformCfg = {
+      cacheFS: new Map(),
       config: {
         cwd: process.cwd(),
         extensionsToTreatAsEsm: [],
@@ -161,6 +162,7 @@ describe('NgJestTransformer', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const transformSyncMock = transformSync as unknown as jest.MockInstance<unknown, any>;
     const transformCfg = {
+      cacheFS: new Map(),
       config: {
         cwd: process.cwd(),
         extensionsToTreatAsEsm: [],

--- a/src/ng-jest-transformer.ts
+++ b/src/ng-jest-transformer.ts
@@ -50,7 +50,8 @@ export class NgJestTransformer extends TsJestTransformer {
     filePath: Config.Path,
     transformOptions: TransformOptionsTsJest,
   ): TransformedSource | string {
-    const configSet = this._createConfigSet(transformOptions.config);
+    // @ts-expect-error we are accessing the private cache to avoid creating new objects all the time
+    const configSet = super._configsFor(transformOptions);
     /**
      * TypeScript < 4.5 doesn't support compiling `.mjs` file by default when running `tsc` which throws error. Also we
      * transform `js` files from `node_modules` assuming that `node_modules` contains compiled files to speed up compilation.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Instead of creating `ConfigSet` instances all the time (which is an expensive operation, as it involves path concatenations, merging configurations, reading from disk...), we use a private method in `ts-jest` that caches the configurations.

Kind of a follow-up to https://github.com/thymikee/jest-preset-angular/pull/1310 and inspired by the discussions in https://github.com/thymikee/jest-preset-angular/pull/1313.

This patch results in significant decrease in the execution time of our test harness: from 821s to 694s.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`npm test` is passing. Our test harness runs without any issues with this patch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
