### PR TITLE
build: drop Angular 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "esbuild": ">=0.13.8"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=0.1002.4",
-    "@angular/compiler-cli": ">=10.0.0",
-    "@angular/core": ">=10.0.0",
-    "@angular/platform-browser-dynamic": ">=10.0.0"
+    "@angular-devkit/build-angular": ">=0.1102.19",
+    "@angular/compiler-cli": ">=11.2.14",
+    "@angular/core": ">=11.2.14",
+    "@angular/platform-browser-dynamic": ">=11.2.14"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~13.3.2",


### PR DESCRIPTION
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Angular 10 is no longer supported, see https://angular.io/guide/releases#support-policy-and-schedule The minimum support Angular version now is 11

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

**N.A.**
