### PR TITLE
feat: exclude `ng-jest-resolver` from default/esm presets

### DIFF
--- a/presets/index.js
+++ b/presets/index.js
@@ -7,7 +7,6 @@ const basePreset = {
       stringifyContentPathRegex: '\\.(html|svg)$',
     },
   },
-  resolver: 'jest-preset-angular/build/resolvers/ng-jest-resolver.js',
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['ts', 'html', 'js', 'json', 'mjs'],
   snapshotSerializers,

--- a/src/config/__snapshots__/jest-preset.spec.ts.snap
+++ b/src/config/__snapshots__/jest-preset.spec.ts.snap
@@ -15,7 +15,6 @@ Object {
     "json",
     "mjs",
   ],
-  "resolver": "jest-preset-angular/build/resolvers/ng-jest-resolver.js",
   "snapshotSerializers": Array [
     "jest-preset-angular/build/serializers/html-comment",
     "jest-preset-angular/build/serializers/ng-snapshot",
@@ -53,7 +52,6 @@ Object {
   "moduleNameMapper": Object {
     "tslib": "tslib/tslib.es6.js",
   },
-  "resolver": "jest-preset-angular/build/resolvers/ng-jest-resolver.js",
   "snapshotSerializers": Array [
     "jest-preset-angular/build/serializers/html-comment",
     "jest-preset-angular/build/serializers/ng-snapshot",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Jest 28 correctly resolves Angular package format files so the `ng-jest-resolver` can be marked as optional

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**