### PR TITLE
fix: add missing jest and typescript to peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "@angular-devkit/build-angular": ">=0.1102.19",
     "@angular/compiler-cli": ">=11.2.14",
     "@angular/core": ">=11.2.14",
-    "@angular/platform-browser-dynamic": ">=11.2.14"
+    "@angular/platform-browser-dynamic": ">=11.2.14",
+    "jest": "^28.0.0",
+    "typescript": ">=4.3"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~13.3.2",


### PR DESCRIPTION
This PR adds peer deps for jest and typescript, so yarn 3 does not complain about it missing in a normal angular workspace

## Summary

This PR fixes #1441

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

