### PR TITLE
feat(presets): use `.mjs` extension for ESM preset

### DIFF
--- a/presets/defaults-esm/jest-preset.d.ts
+++ b/presets/defaults-esm/jest-preset.d.ts
@@ -1,0 +1,34 @@
+declare const _default: {
+  extensionsToTreatAsEsm: string[];
+  globals: {
+    'ts-jest': {
+      useESM: boolean;
+      tsconfig?: string | boolean | import('ts-jest').RawCompilerOptions | undefined;
+      isolatedModules?: boolean | undefined;
+      compiler?: string | undefined;
+      astTransformers?: import('ts-jest').ConfigCustomTransformer | undefined;
+      diagnostics?:
+        | boolean
+        | {
+            pretty?: boolean | undefined;
+            ignoreCodes?: string | number | Array<string | number> | undefined;
+            exclude?: string[] | undefined;
+            warnOnly?: boolean | undefined;
+          }
+        | undefined;
+      babelConfig?: string | boolean | import('@babel/core').TransformOptions | undefined;
+      stringifyContentPathRegex?: string | RegExp | undefined;
+    };
+  };
+  moduleNameMapper: {
+    tslib: string;
+  };
+  transform: {
+    '^.+\\.(ts|js|html|svg)$': string;
+  };
+  transformIgnorePatterns: string[];
+  testEnvironment: string;
+  moduleFileExtensions: string[];
+  snapshotSerializers: string[];
+};
+export default _default;

--- a/presets/defaults-esm/jest-preset.js
+++ b/presets/defaults-esm/jest-preset.js
@@ -1,1 +1,0 @@
-module.exports = require('..').defaultsESM;

--- a/presets/defaults-esm/jest-preset.mjs
+++ b/presets/defaults-esm/jest-preset.mjs
@@ -1,0 +1,3 @@
+import ngJestPreset from '../';
+
+export default ngJestPreset.defaultsESM;

--- a/presets/defaults/jest-preset.d.ts
+++ b/presets/defaults/jest-preset.d.ts
@@ -1,0 +1,11 @@
+declare const _default: {
+  transformIgnorePatterns: string[];
+  transform: {
+    '^.+\\.(ts|js|mjs|html|svg)$': string;
+  };
+  globals: import('ts-jest').GlobalConfigTsJest;
+  testEnvironment: string;
+  moduleFileExtensions: string[];
+  snapshotSerializers: string[];
+};
+export default _default;

--- a/presets/index.js
+++ b/presets/index.js
@@ -1,3 +1,6 @@
-const ngJestPresets = require('../build/presets').default;
+const ngJestPresets = require('../build/presets');
 
-module.exports = ngJestPresets;
+module.exports = {
+  defaults: ngJestPresets.defaultPreset,
+  defaultsESM: ngJestPresets.defaultEsmPreset,
+};

--- a/src/presets/__snapshots__/index.spec.ts.snap
+++ b/src/presets/__snapshots__/index.spec.ts.snap
@@ -2,49 +2,52 @@
 
 exports[`Jest presets should have the correct types which come from \`ts-jest\` 1`] = `
 "declare const _default: {
-  defaults: {
-    transformIgnorePatterns: string[];
-    transform: {
-      '^.+\\\\\\\\.(ts|js|mjs|html|svg)$': string;
-    };
-    globals: import('ts-jest').GlobalConfigTsJest;
-    testEnvironment: string;
-    moduleFileExtensions: string[];
-    snapshotSerializers: string[];
+  transformIgnorePatterns: string[];
+  transform: {
+    '^.+\\\\\\\\.(ts|js|mjs|html|svg)$': string;
   };
-  defaultsESM: {
-    extensionsToTreatAsEsm: string[];
-    globals: {
-      'ts-jest': {
-        useESM: boolean;
-        tsconfig?: string | boolean | import('ts-jest').RawCompilerOptions | undefined;
-        isolatedModules?: boolean | undefined;
-        compiler?: string | undefined;
-        astTransformers?: import('ts-jest').ConfigCustomTransformer | undefined;
-        diagnostics?:
-          | boolean
-          | {
-              pretty?: boolean | undefined;
-              ignoreCodes?: string | number | Array<string | number> | undefined;
-              exclude?: string[] | undefined;
-              warnOnly?: boolean | undefined;
-            }
-          | undefined;
-        babelConfig?: string | boolean | import('@babel/core').TransformOptions | undefined;
-        stringifyContentPathRegex?: string | RegExp | undefined;
-      };
+  globals: import('ts-jest').GlobalConfigTsJest;
+  testEnvironment: string;
+  moduleFileExtensions: string[];
+  snapshotSerializers: string[];
+};
+export default _default;
+"
+`;
+
+exports[`Jest presets should have the correct types which come from \`ts-jest\` 2`] = `
+"declare const _default: {
+  extensionsToTreatAsEsm: string[];
+  globals: {
+    'ts-jest': {
+      useESM: boolean;
+      tsconfig?: string | boolean | import('ts-jest').RawCompilerOptions | undefined;
+      isolatedModules?: boolean | undefined;
+      compiler?: string | undefined;
+      astTransformers?: import('ts-jest').ConfigCustomTransformer | undefined;
+      diagnostics?:
+        | boolean
+        | {
+            pretty?: boolean | undefined;
+            ignoreCodes?: string | number | Array<string | number> | undefined;
+            exclude?: string[] | undefined;
+            warnOnly?: boolean | undefined;
+          }
+        | undefined;
+      babelConfig?: string | boolean | import('@babel/core').TransformOptions | undefined;
+      stringifyContentPathRegex?: string | RegExp | undefined;
     };
-    moduleNameMapper: {
-      tslib: string;
-    };
-    transform: {
-      '^.+\\\\\\\\.(ts|js|html|svg)$': string;
-    };
-    transformIgnorePatterns: string[];
-    testEnvironment: string;
-    moduleFileExtensions: string[];
-    snapshotSerializers: string[];
   };
+  moduleNameMapper: {
+    tslib: string;
+  };
+  transform: {
+    '^.+\\\\\\\\.(ts|js|html|svg)$': string;
+  };
+  transformIgnorePatterns: string[];
+  testEnvironment: string;
+  moduleFileExtensions: string[];
+  snapshotSerializers: string[];
 };
 export default _default;
 "

--- a/src/presets/index.spec.ts
+++ b/src/presets/index.spec.ts
@@ -1,14 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 
-import presets from '../../presets';
+import { defaultPreset, defaultEsmPreset } from './';
 
 describe('Jest presets', () => {
-  test.each([presets.defaults, presets.defaultsESM])('should return the correct jest config', (preset) => {
+  test.each([defaultPreset, defaultEsmPreset])('should return the correct jest config', (preset) => {
     expect(preset).toMatchSnapshot();
   });
 
-  test('should have the correct types which come from `ts-jest`', () => {
-    expect(fs.readFileSync(path.join(__dirname, '..', '..', 'presets', 'index.d.ts'), 'utf-8')).toMatchSnapshot();
+  test.each([
+    path.join(__dirname, '..', '..', 'presets/defaults/jest-preset.d.ts'),
+    path.join(__dirname, '..', '..', 'presets/defaults-esm/jest-preset.d.ts'),
+  ])('should have the correct types which come from `ts-jest`', (presetTypes) => {
+    expect(fs.readFileSync(presetTypes, 'utf-8')).toMatchSnapshot();
   });
 });

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -17,29 +17,30 @@ const baseConfig: Pick<
   snapshotSerializers,
 };
 
-export default {
-  defaults: {
-    ...baseConfig,
-    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
-    transform: {
-      '^.+\\.(ts|js|mjs|html|svg)$': 'jest-preset-angular',
-    },
-  },
-  defaultsESM: {
-    ...baseConfig,
-    extensionsToTreatAsEsm: ['.ts'],
-    globals: {
-      'ts-jest': {
-        ...baseConfig.globals['ts-jest'],
-        useESM: true,
-      },
-    },
-    moduleNameMapper: {
-      tslib: 'tslib/tslib.es6.js',
-    },
-    transform: {
-      '^.+\\.(ts|js|html|svg)$': 'jest-preset-angular',
-    },
-    transformIgnorePatterns: ['node_modules/(?!tslib)'],
+const defaultPreset = {
+  ...baseConfig,
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transform: {
+    '^.+\\.(ts|js|mjs|html|svg)$': 'jest-preset-angular',
   },
 };
+
+const defaultEsmPreset = {
+  ...baseConfig,
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      ...baseConfig.globals['ts-jest'],
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    tslib: 'tslib/tslib.es6.js',
+  },
+  transform: {
+    '^.+\\.(ts|js|html|svg)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!tslib)'],
+};
+
+export { defaultPreset, defaultEsmPreset };


### PR DESCRIPTION
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->
ESM preset now uses `.mjs` extensions which cannot use with `require` syntax if one is doing it.

## Other information
**N.A.**