### PR TITLE
fix: supporting future unstable versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "esbuild": ">=0.13.8"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=0.1102.19",
-    "@angular/compiler-cli": ">=11.2.14",
-    "@angular/core": ">=11.2.14",
-    "@angular/platform-browser-dynamic": ">=11.2.14",
+    "@angular-devkit/build-angular": ">=0.1102.19 <14.0.0",
+    "@angular/compiler-cli": ">=11.2.14 <14.0.0",
+    "@angular/core": ">=11.2.14 <14.0.0",
+    "@angular/platform-browser-dynamic": ">=11.2.14 <14.0.0",
     "jest": "^28.0.0",
     "typescript": ">=4.3"
   },


### PR DESCRIPTION
## Summary

Allows to work with alpha, beta, rc etc.

## Test plan

CI/CD doesn't fail, no regressions

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information

The plan is to avoid errors like:

```
npm WARN Found: @angular/compiler-cli@14.0.0-next.15
npm WARN Could not resolve dependency:
npm WARN peer @angular/compiler-cli@">=10.0.0" from jest-preset-angular@11.1.2
```