### PR TITLE
fix: supporting angular 14 alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "esbuild": ">=0.13.8"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=0.1102.19 <14.0.0",
-    "@angular/compiler-cli": ">=11.2.14 <14.0.0",
-    "@angular/core": ">=11.2.14 <14.0.0",
-    "@angular/platform-browser-dynamic": ">=11.2.14 <14.0.0",
+    "@angular-devkit/build-angular": ">=0.1102.19 || 14.0.0-alpha - 14",
+    "@angular/compiler-cli": ">=11.2.14 || 14.0.0-alpha - 14",
+    "@angular/core": ">=11.2.14 || 14.0.0-alpha - 14",
+    "@angular/platform-browser-dynamic": ">=11.2.14 || 14.0.0-alpha - 14",
     "jest": "^28.0.0",
     "typescript": ">=4.3"
   },


### PR DESCRIPTION
## Summary

fix renovate bot to avoid npm install failures on Angular 14-next, and make pipelines green.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: a14@0.0.0
npm ERR! Found: @angular-devkit/build-angular@14.0.0-next.13
npm ERR! node_modules/@angular-devkit/build-angular
npm ERR!   dev @angular-devkit/build-angular@"14.0.0-next.13" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @angular-devkit/build-angular@">=0.1102.19 <14.0.0" from jest-preset-angular@12.0.0-next.2
npm ERR! node_modules/jest-preset-angular
npm ERR!   dev jest-preset-angular@"12.0.0-next.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /tmp/renovate-cache/others/npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /tmp/renovate-cache/others/npm/_logs/2022-05-08T22_11_53_258Z-debug-0.log
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
