### PR TITLE
feat: allow configuring `destroyAfterEach` for setup test env

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
     es6: true,
     'jest/globals': true,
   },
+  globals: {
+    globalThis: false,
+  },
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,9 +1,17 @@
 require('zone.js/bundles/zone-testing-bundle.umd');
-
 const { getTestBed } = require('@angular/core/testing');
 const {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } = require('@angular/platform-browser-dynamic/testing');
 
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
+if (configuredDestroyAfterEach !== undefined) {
+  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+    teardown: {
+      destroyAfterEach: configuredDestroyAfterEach,
+    },
+  });
+} else {
+  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+}

--- a/setup-jest.mjs
+++ b/setup-jest.mjs
@@ -2,4 +2,13 @@ import 'zone.js/fesm2015/zone-testing-bundle.min.js';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
+if (configuredDestroyAfterEach !== undefined) {
+  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+    teardown: {
+      destroyAfterEach: configuredDestroyAfterEach,
+    },
+  });
+} else {
+  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+}

--- a/src/config/setup-jest.spec.ts
+++ b/src/config/setup-jest.spec.ts
@@ -46,14 +46,23 @@ describe('setup-jest', () => {
   };
 
   beforeEach(() => {
+    delete globalThis.ngJest;
     jest.clearAllMocks();
   });
 
   test('should initialize test environment with getTestBed() and initTestEnvironment() for CJS setup-jest', async () => {
+    globalThis.ngJest = {
+      destroyAfterEach: true,
+    };
     await import('../../setup-jest');
 
     expect(mockUmdZoneJs).toHaveBeenCalled();
     assertOnInitTestEnv();
+    expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
+      teardown: {
+        destroyAfterEach: true,
+      },
+    });
   });
 
   test('should initialize test environment with getTestBed() and initTestEnvironment() for ESM setup-jest', async () => {
@@ -61,5 +70,6 @@ describe('setup-jest', () => {
 
     expect(mockEsmZoneJs).toHaveBeenCalled();
     assertOnInitTestEnv();
+    expect(mockInitTestEnvironment.mock.calls[0][2]).toBeUndefined();
   });
 });

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,7 +4,8 @@ declare global {
   var ngJest: {
     skipNgcc?: boolean;
     tsconfig?: string;
-  };
+    destroyAfterEach?: boolean;
+  } | undefined;
 }
 
 export {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
     "module": "CommonJS",
     "lib": ["esnext", "dom"],
     "types": ["node", "jest"]
-  }
+  },
+  "files": ["src/global.d.ts"]
 }

--- a/website/docs/getting-started/test-environment.md
+++ b/website/docs/getting-started/test-environment.md
@@ -9,3 +9,19 @@ we also make sure Jest test methods run in Zone context. Then we initialize the 
 
 While `setup-jest.js` above is for running Jest with **CommonJS** mode, we also provide [`setup-jest.mjs`](https://github.com/thymikee/jest-preset-angular/blob/main/setup-jest.mjs)
 to run with **ESM** mode.
+
+### Configure test environment
+
+When creating Angular test environment with `TestBed`, it is possible to specify the behavior of `teardown` via `globalThis` in the Jest setup file.
+For example:
+
+```ts
+// setup-test.ts
+globalThis.ngJest = {
+  destroyAfterEach: true,
+};
+
+import 'jest-preset-angular/setup-jest';
+```
+
+`jest-preset-angular` will look at `globalThis.ngJest` and pass the correct `destroyAfterEach` to `TestBed`.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Users can configure `destroyAfterEach` via `globalThis` in the setup Jest file. For example
```
// setup-jest.ts
globalThis.ngJest = {
     destroyAfterEach: true
}

import 'jest-preset-angular/setup-jest';
```

Closes #1466 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**