### PR TITLE
feat: allow passing the whole ModuleTeardownOptions

### DIFF
--- a/setup-jest.js
+++ b/setup-jest.js
@@ -5,7 +5,14 @@ const {
   platformBrowserDynamicTesting,
 } = require('@angular/platform-browser-dynamic/testing');
 
-const teardown = globalThis.ngJest?.teardown;
+let teardown = globalThis.ngJest?.teardown;
+const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
+if (configuredDestroyAfterEach) {
+  teardown = {
+    destroyAfterEach: true,
+  };
+}
+
 if (teardown !== undefined) {
   getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
     teardown,

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -8,6 +8,11 @@ const {
 let teardown = globalThis.ngJest?.teardown;
 const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
 if (configuredDestroyAfterEach) {
+  console.warn(
+    'Passing destroyAfterEach for configuring the test environment has been deprecated.' +
+      ' Please pass a `teardown` object with ModuleTeardownOptions interface instead,' +
+      ' see https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/packages/core/testing/src/test_bed_common.ts#L98'
+  );
   teardown = {
     destroyAfterEach: true,
   };

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -5,12 +5,10 @@ const {
   platformBrowserDynamicTesting,
 } = require('@angular/platform-browser-dynamic/testing');
 
-const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
-if (configuredDestroyAfterEach !== undefined) {
+const teardown = globalThis.ngJest?.teardown;
+if (teardown !== undefined) {
   getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
-    teardown: {
-      destroyAfterEach: configuredDestroyAfterEach,
-    },
+    teardown,
   });
 } else {
   getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/setup-jest.mjs
+++ b/setup-jest.mjs
@@ -2,12 +2,10 @@ import 'zone.js/fesm2015/zone-testing-bundle.min.js';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
-const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
-if (configuredDestroyAfterEach !== undefined) {
+const teardown = globalThis.ngJest?.teardown;
+if (teardown !== undefined) {
   getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
-    teardown: {
-      destroyAfterEach: configuredDestroyAfterEach,
-    },
+    teardown,
   });
 } else {
   getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/setup-jest.mjs
+++ b/setup-jest.mjs
@@ -6,6 +6,9 @@ let teardown = globalThis.ngJest?.teardown;
 const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
 
 if (configuredDestroyAfterEach) {
+  console.warn('Passing destroyAfterEach for configuring the test environment has been deprecated.' +
+    ' Please pass a `teardown` object with ModuleTeardownOptions interface instead,' +
+    ' see https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/packages/core/testing/src/test_bed_common.ts#L98');
   teardown = {
     destroyAfterEach: true,
   };

--- a/setup-jest.mjs
+++ b/setup-jest.mjs
@@ -2,7 +2,15 @@ import 'zone.js/fesm2015/zone-testing-bundle.min.js';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
-const teardown = globalThis.ngJest?.teardown;
+let teardown = globalThis.ngJest?.teardown;
+const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
+
+if (configuredDestroyAfterEach) {
+  teardown = {
+    destroyAfterEach: true,
+  };
+}
+
 if (teardown !== undefined) {
   getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
     teardown,

--- a/src/config/setup-jest.spec.ts
+++ b/src/config/setup-jest.spec.ts
@@ -52,7 +52,9 @@ describe('setup-jest', () => {
 
   test('should initialize test environment with getTestBed() and initTestEnvironment() for CJS setup-jest', async () => {
     globalThis.ngJest = {
-      destroyAfterEach: true,
+      teardown: {
+        destroyAfterEach: true,
+      },
     };
     await import('../../setup-jest');
 

--- a/src/config/setup-jest.spec.ts
+++ b/src/config/setup-jest.spec.ts
@@ -51,46 +51,87 @@ describe('setup-jest', () => {
     jest.resetModules();
   });
 
-  test('should initialize test environment with getTestBed() and initTestEnvironment() for CJS setup-jest', async () => {
-    globalThis.ngJest = {
-      teardown: {
-        destroyAfterEach: false,
-        rethrowErrors: true,
-      },
-    };
-    await import('../../setup-jest');
+  describe('for CJS setup-jest, test environment initialization', () => {
+    test('should call getTestBed() and initTestEnvironment() with the ModuleTeardownOptions object passed to ngJest', async () => {
+      globalThis.ngJest = {
+        teardown: {
+          destroyAfterEach: false,
+          rethrowErrors: true,
+        },
+      };
+      await import('../../setup-jest');
 
-    expect(mockUmdZoneJs).toHaveBeenCalled();
-    assertOnInitTestEnv();
-    expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
-      teardown: {
-        destroyAfterEach: false,
-        rethrowErrors: true,
-      },
+      expect(mockUmdZoneJs).toHaveBeenCalled();
+      assertOnInitTestEnv();
+      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
+        teardown: {
+          destroyAfterEach: false,
+          rethrowErrors: true,
+        },
+      });
     });
-  });
 
-  test('should initialize test environment with getTestBed() and initTestEnvironment() for CJS setup-jest / 2', async () => {
-    globalThis.ngJest = {
-      destroyAfterEach: true,
-    };
-
-    await import('../../setup-jest');
-
-    expect(mockUmdZoneJs).toHaveBeenCalled();
-    assertOnInitTestEnv();
-    expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
-      teardown: {
+    test('should call getTestBed() and initTestEnvironment() with the destroyAfterEach passed to ngJest', async () => {
+      const spyConsoleWarn = (console.warn = jest.fn());
+      globalThis.ngJest = {
         destroyAfterEach: true,
-      },
+      };
+
+      await import('../../setup-jest');
+
+      expect(mockUmdZoneJs).toHaveBeenCalled();
+      expect(spyConsoleWarn).toHaveBeenCalled();
+      expect(spyConsoleWarn.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"Passing destroyAfterEach for configuring the test environment has been deprecated. Please pass a \`teardown\` object with ModuleTeardownOptions interface instead, see https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/packages/core/testing/src/test_bed_common.ts#L98"`,
+      );
+      assertOnInitTestEnv();
+      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
+        teardown: {
+          destroyAfterEach: true,
+        },
+      });
     });
   });
 
-  test('should initialize test environment with getTestBed() and initTestEnvironment() for ESM setup-jest', async () => {
-    await import('../../setup-jest.mjs');
+  describe('for ESM setup-jest, test environment initialization', () => {
+    test('should call getTestBed() and initTestEnvironment() with the ModuleTeardownOptions object passed to ngJest', async () => {
+      globalThis.ngJest = {
+        teardown: {
+          destroyAfterEach: false,
+          rethrowErrors: true,
+        },
+      };
+      await import('../../setup-jest.mjs');
 
-    expect(mockEsmZoneJs).toHaveBeenCalled();
-    assertOnInitTestEnv();
-    expect(mockInitTestEnvironment.mock.calls[0][2]).toBeUndefined();
+      expect(mockEsmZoneJs).toHaveBeenCalled();
+      assertOnInitTestEnv();
+      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
+        teardown: {
+          destroyAfterEach: false,
+          rethrowErrors: true,
+        },
+      });
+    });
+
+    test('should call getTestBed() and initTestEnvironment() with the destroyAfterEach passed to ngJest', async () => {
+      const spyConsoleWarn = (console.warn = jest.fn());
+      globalThis.ngJest = {
+        destroyAfterEach: true,
+      };
+
+      await import('../../setup-jest.mjs');
+
+      expect(mockEsmZoneJs).toHaveBeenCalled();
+      expect(spyConsoleWarn).toHaveBeenCalled();
+      expect(spyConsoleWarn.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"Passing destroyAfterEach for configuring the test environment has been deprecated. Please pass a \`teardown\` object with ModuleTeardownOptions interface instead, see https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/packages/core/testing/src/test_bed_common.ts#L98"`,
+      );
+      assertOnInitTestEnv();
+      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
+        teardown: {
+          destroyAfterEach: true,
+        },
+      });
+    });
   });
 });

--- a/src/config/setup-jest.spec.ts
+++ b/src/config/setup-jest.spec.ts
@@ -48,14 +48,33 @@ describe('setup-jest', () => {
   beforeEach(() => {
     delete globalThis.ngJest;
     jest.clearAllMocks();
+    jest.resetModules();
   });
 
   test('should initialize test environment with getTestBed() and initTestEnvironment() for CJS setup-jest', async () => {
     globalThis.ngJest = {
       teardown: {
-        destroyAfterEach: true,
+        destroyAfterEach: false,
+        rethrowErrors: true,
       },
     };
+    await import('../../setup-jest');
+
+    expect(mockUmdZoneJs).toHaveBeenCalled();
+    assertOnInitTestEnv();
+    expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
+      teardown: {
+        destroyAfterEach: false,
+        rethrowErrors: true,
+      },
+    });
+  });
+
+  test('should initialize test environment with getTestBed() and initTestEnvironment() for CJS setup-jest / 2', async () => {
+    globalThis.ngJest = {
+      destroyAfterEach: true,
+    };
+
     await import('../../setup-jest');
 
     expect(mockUmdZoneJs).toHaveBeenCalled();

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,10 +1,12 @@
 /* eslint-disable */
 
+import {ModuleTeardownOptions} from "@angular/core/testing";
+
 declare global {
   var ngJest: {
     skipNgcc?: boolean;
     tsconfig?: string;
-    destroyAfterEach?: boolean;
+    teardown?: ModuleTeardownOptions;
   } | undefined;
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,11 +1,12 @@
 /* eslint-disable */
 
-import {ModuleTeardownOptions} from "@angular/core/testing";
+import type { ModuleTeardownOptions } from "@angular/core/testing";
 
 declare global {
   var ngJest: {
     skipNgcc?: boolean;
     tsconfig?: string;
+    destroyAfterEach?: boolean;
     teardown?: ModuleTeardownOptions;
   } | undefined;
 }

--- a/website/docs/getting-started/test-environment.md
+++ b/website/docs/getting-started/test-environment.md
@@ -24,4 +24,4 @@ globalThis.ngJest = {
 import 'jest-preset-angular/setup-jest';
 ```
 
-`jest-preset-angular` will look at `globalThis.ngJest` and pass the correct `destroyAfterEach` to `TestBed`.
+`jest-preset-angular` will look at `globalThis.ngJest` and pass the correct `ModuleTearDownOptions` object to `TestBed`.

--- a/website/docs/getting-started/test-environment.md
+++ b/website/docs/getting-started/test-environment.md
@@ -24,4 +24,4 @@ globalThis.ngJest = {
 import 'jest-preset-angular/setup-jest';
 ```
 
-`jest-preset-angular` will look at `globalThis.ngJest` and pass the correct `ModuleTearDownOptions` object to `TestBed`.
+`jest-preset-angular` will look at `globalThis.ngJest` and pass the correct [`ModuleTearDownOptions`](https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/packages/core/testing/src/test_bed_common.ts#L98) object to `TestBed`.


### PR DESCRIPTION

## Summary

In  #1466 , I've forgotten to mention that there was a whole configuration object for the teardown options. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

People who passed the `destroyAfterEach` flag will need to pass the whole options object

## Other information
