### PR TITLE
Added SVG to transform config explanation

### DIFF
--- a/website/docs/getting-started/options.md
+++ b/website/docs/getting-started/options.md
@@ -83,4 +83,4 @@ Jest runs with `jest-preset-angular` neither in browser nor through dev server. 
   To remove such specific attributes use `no-ng-attributes` serializer. You need to add `no-ng-attributes` serializer manually.
 - `"testEnvironment"` – the test environment to run on.
 - `"transformIgnorePatterns"`: instruct Jest to transform any `.mjs` files which come from `node_modules`.
-- `"transform"` – run every `TS`, `JS`, `MJS`, or `HTML` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
+- `"transform"` – run every `TS`, `JS`, `MJS`, `HTML`, or `SVG` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.

--- a/website/versioned_docs/version-10.x/getting-started/options.md
+++ b/website/versioned_docs/version-10.x/getting-started/options.md
@@ -55,7 +55,7 @@ Jest runs with `jest-preset-angular` neither in browser nor through dev server. 
 ### Brief explanation of config
 
 - we're using some `"globals"` to pass information about where our tsconfig.json file is that we'd like to be able to transform HTML files through `ts-jest`.
-- `"transform"` – run every TS, JS, or HTML file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
+- `"transform"` – run every `TS`, `JS`, `MJS`, `HTML`, or `SVG` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
 - `"testEnvironment"` – the test environment to run on.
 - `"moduleFileExtensions"` – our modules are TypeScript (`ts`), HTML (`html`), JavaScript (`js`) and JSON (`json`) files.
 - `"moduleNameMapper"` – if you're using absolute imports here's how to tell Jest where to look for them; uses regex.

--- a/website/versioned_docs/version-11.0/getting-started/options.md
+++ b/website/versioned_docs/version-11.0/getting-started/options.md
@@ -66,4 +66,4 @@ Jest runs with `jest-preset-angular` neither in browser nor through dev server. 
   To remove such specific attributes use `no-ng-attributes` serializer. You need to add `no-ng-attributes` serializer manually.
 - `"testEnvironment"` – the test environment to run on.
 - `"transformIgnorePatterns"`: instruct Jest to transform any `.mjs` files which come from `node_modules`.
-- `"transform"` – run every `TS`, `JS`, `MJS`, or `HTML` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
+- `"transform"` – run every `TS`, `JS`, `MJS`, `HTML`, or `SVG` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.

--- a/website/versioned_docs/version-11.1/getting-started/options.md
+++ b/website/versioned_docs/version-11.1/getting-started/options.md
@@ -66,4 +66,4 @@ Jest runs with `jest-preset-angular` neither in browser nor through dev server. 
   To remove such specific attributes use `no-ng-attributes` serializer. You need to add `no-ng-attributes` serializer manually.
 - `"testEnvironment"` – the test environment to run on.
 - `"transformIgnorePatterns"`: instruct Jest to transform any `.mjs` files which come from `node_modules`.
-- `"transform"` – run every `TS`, `JS`, `MJS`, or `HTML` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
+- `"transform"` – run every `TS`, `JS`, `MJS`, `HTML`, or `SVG` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.

--- a/website/versioned_docs/version-12.0/getting-started/options.md
+++ b/website/versioned_docs/version-12.0/getting-started/options.md
@@ -83,4 +83,4 @@ Jest runs with `jest-preset-angular` neither in browser nor through dev server. 
   To remove such specific attributes use `no-ng-attributes` serializer. You need to add `no-ng-attributes` serializer manually.
 - `"testEnvironment"` – the test environment to run on.
 - `"transformIgnorePatterns"`: instruct Jest to transform any `.mjs` files which come from `node_modules`.
-- `"transform"` – run every `TS`, `JS`, `MJS`, or `HTML` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
+- `"transform"` – run every `TS`, `JS`, `MJS`, `HTML`, or `SVG` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.

--- a/website/versioned_docs/version-9.x/getting-started/options.md
+++ b/website/versioned_docs/version-9.x/getting-started/options.md
@@ -55,7 +55,7 @@ Jest runs with `jest-preset-angular` neither in browser nor through dev server. 
 ### Brief explanation of config
 
 - we're using some `"globals"` to pass information about where our tsconfig.json file is that we'd like to be able to transform HTML files through `ts-jest`.
-- `"transform"` – run every TS, JS, or HTML file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
+- `"transform"` – run every `TS`, `JS`, `MJS`, `HTML`, or `SVG` file through so called _Jest transformer_; this lets Jest understand non-JS syntax.
 - `"testEnvironment"` – the test environment to run on.
 - `"moduleFileExtensions"` – our modules are TypeScript (`ts`), HTML (`html`), JavaScript (`js`) and JSON (`json`) files.
 - `"moduleNameMapper"` – if you're using absolute imports here's how to tell Jest where to look for them; uses regex.


### PR DESCRIPTION
Transform property doesn't explicitly mention SVG, but it is a file transform provided in the RegExp.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Update to the documentation to include SVG in the file transform config description, which is included in the preceding RegExp of the transform property in the example object literal.

## Test plan

None.  Documentation update.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No