### PR TITLE
Allows default and named export for global-setup

### DIFF
--- a/src/config/global-setup.ts
+++ b/src/config/global-setup.ts
@@ -1,6 +1,6 @@
 import { runNgccJestProcessor } from '../utils/ngcc-jest-processor';
 
-const GlobalSetup = () => {
+const globalSetup = async () => {
   const ngJestConfig = globalThis.ngJest;
   const tsconfig = ngJestConfig?.tsconfig;
   if (!ngJestConfig?.skipNgcc) {
@@ -8,4 +8,4 @@ const GlobalSetup = () => {
   }
 }
 
-export default GlobalSetup;
+export default globalSetup;

--- a/src/config/global-setup.ts
+++ b/src/config/global-setup.ts
@@ -6,6 +6,6 @@ const globalSetup = async () => {
   if (!ngJestConfig?.skipNgcc) {
     runNgccJestProcessor(tsconfig);
   }
-}
+};
 
 export default globalSetup;

--- a/src/config/global-setup.ts
+++ b/src/config/global-setup.ts
@@ -1,9 +1,11 @@
 import { runNgccJestProcessor } from '../utils/ngcc-jest-processor';
 
-export = async () => {
+const GlobalSetup = () => {
   const ngJestConfig = globalThis.ngJest;
   const tsconfig = ngJestConfig?.tsconfig;
   if (!ngJestConfig?.skipNgcc) {
     runNgccJestProcessor(tsconfig);
   }
-};
+}
+
+export default GlobalSetup;


### PR DESCRIPTION
## Summary
If someone wants to run another function before calling the global-setup, they can use a named export or a default export for importing the original global-setup function and calling it manually.
## Test plan
Jest already supports default exports for globalSetup functions, so no impact is expected.
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
