### PR TITLE
feat: remove `destroyAfterEach` and `teardown` options

### DIFF
--- a/setup-jest.js
+++ b/setup-jest.js
@@ -5,36 +5,6 @@ const {
   platformBrowserDynamicTesting,
 } = require('@angular/platform-browser-dynamic/testing');
 
-let testEnvironmentOptions = globalThis.ngJest?.testEnvironmentOptions ?? Object.create(null);
-
-const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
-if (configuredDestroyAfterEach) {
-  console.warn(
-    'Passing destroyAfterEach for configuring the test environment has been deprecated.' +
-      ' Please pass a `testEnvironmentOptions` object with TestEnvironmentOptions interface instead,' +
-      ' see https://angular.io/api/core/testing/TestEnvironmentOptions'
-  );
-
-  testEnvironmentOptions = {
-    ...testEnvironmentOptions,
-    teardown: {
-      destroyAfterEach: true,
-    },
-  };
-}
-
-const configuredTeardown = globalThis.ngJest?.teardown;
-if (configuredTeardown) {
-  console.warn(
-    'Passing teardown for configuring the test environment has been deprecated.' +
-      ' Please pass a `testEnvironmentOptions` object with TestEnvironmentOptions interface instead,' +
-      ' see https://angular.io/api/core/testing/TestEnvironmentOptions'
-  );
-
-  testEnvironmentOptions = {
-    ...testEnvironmentOptions,
-    teardown: configuredTeardown,
-  };
-}
+const testEnvironmentOptions = globalThis.ngJest?.testEnvironmentOptions ?? Object.create(null);
 
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), testEnvironmentOptions);

--- a/setup-jest.mjs
+++ b/setup-jest.mjs
@@ -2,36 +2,6 @@ import 'zone.js/fesm2015/zone-testing-bundle.min.js';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
-let testEnvironmentOptions = globalThis.ngJest?.testEnvironmentOptions ?? Object.create(null);
-
-const configuredDestroyAfterEach = globalThis.ngJest?.destroyAfterEach;
-if (configuredDestroyAfterEach) {
-  console.warn(
-    'Passing destroyAfterEach for configuring the test environment has been deprecated.' +
-      ' Please pass a `testEnvironmentOptions` object with TestEnvironmentOptions interface instead,' +
-      ' see https://angular.io/api/core/testing/TestEnvironmentOptions',
-  );
-
-  testEnvironmentOptions = {
-    ...testEnvironmentOptions,
-    teardown: {
-      destroyAfterEach: true,
-    },
-  };
-}
-
-const configuredTeardown = globalThis.ngJest?.teardown;
-if (configuredTeardown) {
-  console.warn(
-    'Passing teardown for configuring the test environment has been deprecated.' +
-      ' Please pass a `testEnvironmentOptions` object with TestEnvironmentOptions interface instead,' +
-      ' see https://angular.io/api/core/testing/TestEnvironmentOptions',
-  );
-
-  testEnvironmentOptions = {
-    ...testEnvironmentOptions,
-    teardown: configuredTeardown,
-  };
-}
+const testEnvironmentOptions = globalThis.ngJest?.testEnvironmentOptions ?? Object.create(null);
 
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), testEnvironmentOptions);

--- a/src/config/setup-jest.spec.ts
+++ b/src/config/setup-jest.spec.ts
@@ -52,51 +52,6 @@ describe('setup-jest', () => {
   });
 
   describe('for CJS setup-jest, test environment initialization', () => {
-    test('should call getTestBed() and initTestEnvironment() with the ModuleTeardownOptions object passed to ngJest', async () => {
-      const spyConsoleWarn = (console.warn = jest.fn());
-      globalThis.ngJest = {
-        teardown: {
-          destroyAfterEach: false,
-          rethrowErrors: true,
-        },
-      };
-      await import('../../setup-jest');
-
-      expect(mockUmdZoneJs).toHaveBeenCalled();
-      expect(spyConsoleWarn).toHaveBeenCalled();
-      expect(spyConsoleWarn.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"Passing teardown for configuring the test environment has been deprecated. Please pass a \`testEnvironmentOptions\` object with TestEnvironmentOptions interface instead, see https://angular.io/api/core/testing/TestEnvironmentOptions"`,
-      );
-      assertOnInitTestEnv();
-      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
-        teardown: {
-          destroyAfterEach: false,
-          rethrowErrors: true,
-        },
-      });
-    });
-
-    test('should call getTestBed() and initTestEnvironment() with the destroyAfterEach passed to ngJest', async () => {
-      const spyConsoleWarn = (console.warn = jest.fn());
-      globalThis.ngJest = {
-        destroyAfterEach: true,
-      };
-
-      await import('../../setup-jest');
-
-      expect(mockUmdZoneJs).toHaveBeenCalled();
-      expect(spyConsoleWarn).toHaveBeenCalled();
-      expect(spyConsoleWarn.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"Passing destroyAfterEach for configuring the test environment has been deprecated. Please pass a \`testEnvironmentOptions\` object with TestEnvironmentOptions interface instead, see https://angular.io/api/core/testing/TestEnvironmentOptions"`,
-      );
-      assertOnInitTestEnv();
-      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
-        teardown: {
-          destroyAfterEach: true,
-        },
-      });
-    });
-
     test('should call getTestBed() and initTestEnvironment() with the testEnvironmentOptions passed to ngJest', async () => {
       globalThis.ngJest = {
         testEnvironmentOptions: {
@@ -125,51 +80,6 @@ describe('setup-jest', () => {
   });
 
   describe('for ESM setup-jest, test environment initialization', () => {
-    test('should call getTestBed() and initTestEnvironment() with the ModuleTeardownOptions object passed to ngJest', async () => {
-      const spyConsoleWarn = (console.warn = jest.fn());
-      globalThis.ngJest = {
-        teardown: {
-          destroyAfterEach: false,
-          rethrowErrors: true,
-        },
-      };
-      await import('../../setup-jest.mjs');
-
-      expect(mockEsmZoneJs).toHaveBeenCalled();
-      expect(spyConsoleWarn).toHaveBeenCalled();
-      expect(spyConsoleWarn.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"Passing teardown for configuring the test environment has been deprecated. Please pass a \`testEnvironmentOptions\` object with TestEnvironmentOptions interface instead, see https://angular.io/api/core/testing/TestEnvironmentOptions"`,
-      );
-      assertOnInitTestEnv();
-      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
-        teardown: {
-          destroyAfterEach: false,
-          rethrowErrors: true,
-        },
-      });
-    });
-
-    test('should call getTestBed() and initTestEnvironment() with the destroyAfterEach passed to ngJest', async () => {
-      const spyConsoleWarn = (console.warn = jest.fn());
-      globalThis.ngJest = {
-        destroyAfterEach: true,
-      };
-
-      await import('../../setup-jest.mjs');
-
-      expect(mockEsmZoneJs).toHaveBeenCalled();
-      expect(spyConsoleWarn).toHaveBeenCalled();
-      expect(spyConsoleWarn.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"Passing destroyAfterEach for configuring the test environment has been deprecated. Please pass a \`testEnvironmentOptions\` object with TestEnvironmentOptions interface instead, see https://angular.io/api/core/testing/TestEnvironmentOptions"`,
-      );
-      assertOnInitTestEnv();
-      expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
-        teardown: {
-          destroyAfterEach: true,
-        },
-      });
-    });
-
     test('should call getTestBed() and initTestEnvironment() with the testEnvironmentOptions passed to ngJest', async () => {
       globalThis.ngJest = {
         testEnvironmentOptions: {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,14 +1,12 @@
 /* eslint-disable */
 
-import type { ModuleTeardownOptions, TestEnvironmentOptions } from '@angular/core/testing';
+import type { TestEnvironmentOptions } from '@angular/core/testing';
 
 declare global {
   var ngJest:
     | {
         skipNgcc?: boolean;
         tsconfig?: string;
-        destroyAfterEach?: boolean;
-        teardown?: ModuleTeardownOptions;
         testEnvironmentOptions?: TestEnvironmentOptions;
       }
     | undefined;


### PR DESCRIPTION
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

`destroyAfterEach` and `teardown` are no longer available to use, please use `testEnvironmentOptions` instead.

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**