### PR TITLE
#1815 remove __ngContext__ from snapshots

### DIFF
--- a/e2e/snapshot-serializers/__tests__/__snapshots__/foo.component.spec.ts.snap
+++ b/e2e/snapshot-serializers/__tests__/__snapshots__/foo.component.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`snapshot should work 1`] = `
 <foo
-  __ngContext__="0"
   condition1={[Function Boolean]}
   condition2="false"
   value1={[Function String]}

--- a/src/serializers/ng-snapshot.ts
+++ b/src/serializers/ng-snapshot.ts
@@ -38,6 +38,7 @@ interface PluginOptions {
 type Indent = (indentSpaces: string) => string;
 type Printer = (elementToSerialize: unknown) => string;
 
+const attributesToRemovePatterns = ['__ngContext'];
 const ivyEnabled = (): boolean => {
   // Should be required lazily, since it will throw an exception
   // `Cannot resolve parameters...`.
@@ -66,7 +67,7 @@ const print = (fixture: unknown, print: Printer, indent: Indent, opts: PluginOpt
       .map((node: VEDebugNode) => Array.from(node.renderElement.childNodes).map(print).join(''))
       .join(opts.edgeSpacing);
   }
-  const attributes = Object.keys(componentInstance).filter((key) => key !== '__ngContext__');
+  const attributes = Object.keys(componentInstance).filter((key) => !attributesToRemovePatterns.includes(key));
   if (attributes.length) {
     componentAttrs += attributes
       .sort()

--- a/src/serializers/ng-snapshot.ts
+++ b/src/serializers/ng-snapshot.ts
@@ -66,7 +66,7 @@ const print = (fixture: unknown, print: Printer, indent: Indent, opts: PluginOpt
       .map((node: VEDebugNode) => Array.from(node.renderElement.childNodes).map(print).join(''))
       .join(opts.edgeSpacing);
   }
-  const attributes = Object.keys(componentInstance);
+  const attributes = Object.keys(componentInstance).filter(key => key !== '__ngContext__');
   if (attributes.length) {
     componentAttrs += attributes
       .sort()

--- a/src/serializers/ng-snapshot.ts
+++ b/src/serializers/ng-snapshot.ts
@@ -38,7 +38,7 @@ interface PluginOptions {
 type Indent = (indentSpaces: string) => string;
 type Printer = (elementToSerialize: unknown) => string;
 
-const attributesToRemovePatterns = ['__ngContext'];
+const attributesToRemovePatterns = ['__ngContext__'];
 const ivyEnabled = (): boolean => {
   // Should be required lazily, since it will throw an exception
   // `Cannot resolve parameters...`.

--- a/src/serializers/ng-snapshot.ts
+++ b/src/serializers/ng-snapshot.ts
@@ -66,7 +66,7 @@ const print = (fixture: unknown, print: Printer, indent: Indent, opts: PluginOpt
       .map((node: VEDebugNode) => Array.from(node.renderElement.childNodes).map(print).join(''))
       .join(opts.edgeSpacing);
   }
-  const attributes = Object.keys(componentInstance).filter(key => key !== '__ngContext__');
+  const attributes = Object.keys(componentInstance).filter((key) => key !== '__ngContext__');
   if (attributes.length) {
     componentAttrs += attributes
       .sort()


### PR DESCRIPTION
## Summary

removes `__ngContext__` from snapshots.

## Test plan

covered by foo component snapshot (see commit)

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The existing snapshots need to be updated. However, with every subsequent change of the internal  `__ngContext__` attribute no change is necessary. 

## Other information

Internal implemenation attribute pollutes the snapshots and should be removed. 