### PR TITLE
Change jest dependency policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "github-files-fetcher": "^1.6.0",
     "glob": "^8.0.3",
     "husky": "^8.0.1",
-    "jest": "^29.1.2",
+    "jest": ">=29.1.2",
     "jest-snapshot-serializer-raw": "^1.2.0",
     "pinst": "^3.0.0",
     "prettier": "^2.7.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

This change will make possible to upgrade `jest` without upgrading `jest-preset-angular`.

Currently we have to release newer version of `jest-preset-angular` every time when new version of jest is released. The current situation is a good example: there is no possibility to upgrade jest but no new version of `jest-preset-angular` available ATM.

There are no any breaking changes. Just possibility to use this package with newer versions of jest.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Not needed.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
