### PR TITLE
feat: support Jest 29

### DIFF
--- a/e2e/ast-transformers/hoisting/jest-isolated.config.js
+++ b/e2e/ast-transformers/hoisting/jest-isolated.config.js
@@ -2,9 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|html)$': [
+      '<rootDir>/../../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/ast-transformers/ng-jit-transformers/jest-isolated.config.js
+++ b/e2e/ast-transformers/ng-jit-transformers/jest-isolated.config.js
@@ -2,10 +2,14 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      ...baseCfg.globals['ts-jest'],
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|mjs|html)$': [
+      '<rootDir>/../../../build/index.js',
+      {
+        ...require('./ts-jest.config'),
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/ast-transformers/ng-jit-transformers/jest.config.js
+++ b/e2e/ast-transformers/ng-jit-transformers/jest.config.js
@@ -1,14 +1,9 @@
 module.exports = {
-  globals: {
-    'ts-jest': {
-      stringifyContentPathRegex: '\\.html$',
-    },
-  },
   resolver: '<rootDir>/../../../build/resolvers/ng-jest-resolver',
   setupFilesAfterEnv: ['<rootDir>/../../../setup-jest.js'],
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|js|mjs|html)$': '<rootDir>/../../../build/index.js',
+    '^.+\\.(ts|js|mjs|html)$': ['<rootDir>/../../../build/index.js', require('./ts-jest.config')],
   },
   transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
 };

--- a/e2e/ast-transformers/ng-jit-transformers/ts-jest.config.js
+++ b/e2e/ast-transformers/ng-jit-transformers/ts-jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  stringifyContentPathRegex: '\\.html$',
+};

--- a/e2e/async/jest-isolated.config.js
+++ b/e2e/async/jest-isolated.config.js
@@ -2,10 +2,14 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      ...baseCfg.globals['ts-jest'],
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|mjs|js|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        ...require('./ts-jest.config'),
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/async/jest.config.js
+++ b/e2e/async/jest.config.js
@@ -1,17 +1,9 @@
 module.exports = {
-  globals: {
-    'ts-jest': {
-      tsconfig: {
-        /** Angular doesn't work with ES2017+
-         * see https://github.com/angular/components/issues/21632#issuecomment-764975917
-         */
-        target: 'ES2016',
-      },
-    },
-  },
   resolver: '<rootDir>/../../build/resolvers/ng-jest-resolver',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/../../setup-jest.js'],
-  transform: { '^.+\\.(ts|mjs|js|html)$': '<rootDir>/../../build/index.js' },
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': ['<rootDir>/../../build/index.js', require('./ts-jest.config')],
+  },
   transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
 };

--- a/e2e/async/ts-jest.config.js
+++ b/e2e/async/ts-jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  tsconfig: {
+    /** Angular doesn't work with ES2017+
+     * see https://github.com/angular/components/issues/21632#issuecomment-764975917
+     */
+    target: 'ES2016',
+  },
+};

--- a/e2e/babel-support/jest-isolated.config.js
+++ b/e2e/babel-support/jest-isolated.config.js
@@ -1,11 +1,11 @@
-const baseCfg = require('./jest.config');
-
 module.exports = {
-  ...baseCfg,
-  globals: {
-    'ts-jest': {
-      ...baseCfg.globals['ts-jest'],
-      isolatedModules: true,
-    },
+  transform: {
+    '^.+\\.(ts|js|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        ...require('./ts-jest.config'),
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/babel-support/jest.config.js
+++ b/e2e/babel-support/jest.config.js
@@ -1,10 +1,5 @@
 module.exports = {
-  globals: {
-    'ts-jest': {
-      babelConfig: true,
-    },
-  },
   transform: {
-    '^.+\\.(ts|js|html)$': '<rootDir>/../../build/index.js',
+    '^.+\\.(ts|js|html)$': ['<rootDir>/../../build/index.js', require('./ts-jest.config')],
   },
 };

--- a/e2e/babel-support/ts-jest.config.js
+++ b/e2e/babel-support/ts-jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  babelConfig: true,
+};

--- a/e2e/custom-typings/jest-isolated.config.js
+++ b/e2e/custom-typings/jest-isolated.config.js
@@ -2,9 +2,12 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    '^.+\\.(ts|js|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/full-ivy-lib/jest-isolated.config.js
+++ b/e2e/full-ivy-lib/jest-isolated.config.js
@@ -2,9 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|mjs|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/jest-globals/jest-isolated.config.js
+++ b/e2e/jest-globals/jest-isolated.config.js
@@ -2,9 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/ng-deep-import/jest-isolated.config.js
+++ b/e2e/ng-deep-import/jest-isolated.config.js
@@ -2,9 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|mjs|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/partial-ivy-lib/jest-isolated.config.js
+++ b/e2e/partial-ivy-lib/jest-isolated.config.js
@@ -2,9 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|mjs|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/path-mapping/jest-isolated.config.js
+++ b/e2e/path-mapping/jest-isolated.config.js
@@ -2,9 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    ...baseCfg.transform,
+    '^.+\\.(ts|js|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/process-js-packages/jest-esm.config.mjs
+++ b/e2e/process-js-packages/jest-esm.config.mjs
@@ -1,14 +1,11 @@
 export default {
-  extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig-esm.spec.json',
+  extensionsToTreatAsEsm: [".ts"],
+  transform: {
+    "^.+\\.(ts|js)$": ["<rootDir>/../../build/index.js", {
+      tsconfig: "tsconfig-esm.spec.json",
       useESM: true,
       isolatedModules: true,
-    },
-  },
-  transform: {
-    '^.+\\.(ts|js)$': '<rootDir>/../../build/index.js',
+    }],
   },
   moduleNameMapper: {
     '@googlemaps/markerclusterer': '@googlemaps/markerclusterer/dist/index.esm.js',

--- a/e2e/process-js-packages/jest.config.js
+++ b/e2e/process-js-packages/jest.config.js
@@ -1,15 +1,17 @@
 module.exports = {
   globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.spec.json',
-      isolatedModules: true,
-    },
     ngJest: {
       processWithEsbuild: ['**/node_modules/lodash-es/*.js'],
     },
   },
   transform: {
-    '^.+\\.(ts|js|mjs)$': '<rootDir>/../../build/index.js',
+    '^.+\\.(ts|js|mjs)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        tsconfig: 'tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
   transformIgnorePatterns: ['node_modules/(?!lodash-es)'],
 };

--- a/e2e/snapshot-serializers/jest-isolated.config.js
+++ b/e2e/snapshot-serializers/jest-isolated.config.js
@@ -2,10 +2,13 @@ const baseCfg = require('./jest.config');
 
 module.exports = {
   ...baseCfg,
-  globals: {
-    'ts-jest': {
-      ...baseCfg.globals['ts-jest'],
-      isolatedModules: true,
-    },
+  transform: {
+    '^.+\\.(ts|js|mjs|html)$': [
+      '<rootDir>/../../build/index.js',
+      {
+        ...require('./ts-jest.config'),
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/e2e/snapshot-serializers/jest.config.js
+++ b/e2e/snapshot-serializers/jest.config.js
@@ -1,9 +1,4 @@
 module.exports = {
-  globals: {
-    'ts-jest': {
-      stringifyContentPathRegex: '\\.html$',
-    },
-  },
   resolver: '<rootDir>/../../build/resolvers/ng-jest-resolver',
   setupFilesAfterEnv: ['<rootDir>/../../setup-jest.js'],
   snapshotSerializers: [
@@ -13,7 +8,7 @@ module.exports = {
   ],
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|js|mjs|html)$': '<rootDir>/../../build/index.js',
+    '^.+\\.(ts|js|mjs|html)$': ['<rootDir>/../../build/index.js', require('./ts-jest.config')],
   },
   transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
 };

--- a/e2e/snapshot-serializers/ts-jest.config.js
+++ b/e2e/snapshot-serializers/ts-jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  stringifyContentPathRegex: '\\.html$',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.spec.json',
-      isolatedModules: true,
-    },
-  },
   moduleNameMapper: {
     '@angular/compiler-cli/ngcc': '<rootDir>/node_modules/@angular/compiler-cli/bundles/ngcc/main-ngcc.js',
   },
@@ -14,6 +8,12 @@ module.exports = {
   snapshotSerializers: [require.resolve('jest-snapshot-serializer-raw')],
   testPathIgnorePatterns: ['/node_modules/', '/examples/', '/e2e/.*/__tests__', '\\.snap$'],
   transform: {
-    '^.+\\.(ts|js|mjs|html)$': '<rootDir>/build/index.js',
+    '^.+\\.(ts|js|mjs|html)$': [
+      '<rootDir>/build/index.js',
+      {
+        tsconfig: 'tsconfig.spec.json',
+        isolatedModules: true,
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jest-environment-jsdom": "^29.0.0",
     "jest-util": "^29.0.0",
     "pretty-format": "^29.0.0",
-    "ts-jest": "^29.0.0"
+    "ts-jest": "^29.0.5"
   },
   "optionalDependencies": {
     "esbuild": ">=0.13.8"

--- a/presets/index.d.ts
+++ b/presets/index.d.ts
@@ -1,46 +1,22 @@
 declare const _default: {
   defaults: {
     transformIgnorePatterns: string[];
-    transform: {
-      '^.+\\.(ts|js|mjs|html|svg)$': string;
-    };
-    globals: import('ts-jest').GlobalConfigTsJest;
+    transform: import('ts-jest').JestConfigWithTsJest['transform'];
     testEnvironment: string;
     moduleFileExtensions: string[];
     snapshotSerializers: string[];
   };
   defaultsESM: {
     extensionsToTreatAsEsm: string[];
-    globals: {
-      'ts-jest': {
-        useESM: boolean;
-        tsconfig?: string | boolean | import('ts-jest').RawCompilerOptions | undefined;
-        isolatedModules?: boolean | undefined;
-        compiler?: string | undefined;
-        astTransformers?: import('ts-jest').ConfigCustomTransformer | undefined;
-        diagnostics?:
-          | boolean
-          | {
-              pretty?: boolean | undefined;
-              ignoreCodes?: string | number | Array<string | number> | undefined;
-              exclude?: string[] | undefined;
-              warnOnly?: boolean | undefined;
-            }
-          | undefined;
-        babelConfig?: string | boolean | import('@babel/core').TransformOptions | undefined;
-        stringifyContentPathRegex?: string | RegExp | undefined;
-      };
-    };
     moduleNameMapper: {
       tslib: string;
     };
-    transform: {
-      '^.+\\.(ts|js|html|svg)$': string;
-    };
+    transform: import('ts-jest').JestConfigWithTsJest['transform'];
     transformIgnorePatterns: string[];
     testEnvironment: string;
     moduleFileExtensions: string[];
     snapshotSerializers: string[];
   };
+  defaultTransformerOptions: import('ts-jest').TsJestTransformerOptions;
 };
 export default _default;

--- a/presets/index.js
+++ b/presets/index.js
@@ -3,4 +3,5 @@ const ngJestPresets = require('../build/presets');
 module.exports = {
   defaults: ngJestPresets.defaultPreset,
   defaultsESM: ngJestPresets.defaultEsmPreset,
+  defaultTransformerOptions: ngJestPresets.defaultTransformerOptions,
 };

--- a/src/compiler/ng-jest-compiler.spec.ts
+++ b/src/compiler/ng-jest-compiler.spec.ts
@@ -9,14 +9,16 @@ describe('NgJestCompiler', () => {
       extensionsToTreatAsEsm: [],
       testMatch: [],
       testRegex: [],
-      globals: {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        'ts-jest': {
-          isolatedModules: true,
-          tsconfig: {
-            sourceMap: false,
+      transform: {
+        '^.+\\.(ts|js|mjs|html|svg)$': [
+          'ts-jest',
+          {
+            isolatedModules: true,
+            tsconfig: {
+              sourceMap: false,
+            },
           },
-        },
+        ],
       },
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     const compiler = new NgJestCompiler(ngJestConfig, new Map());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
+import { TsJestGlobalOptions } from 'ts-jest';
+
 import { NgJestTransformer } from './ng-jest-transformer';
 
 export default {
-  createTransformer: (): NgJestTransformer => new NgJestTransformer(),
+  createTransformer: (tsJestConfig?: TsJestGlobalOptions | undefined): NgJestTransformer =>
+    new NgJestTransformer(tsJestConfig),
 };

--- a/src/ng-jest-transformer.spec.ts
+++ b/src/ng-jest-transformer.spec.ts
@@ -1,10 +1,9 @@
 import { transformSync } from 'esbuild';
+import { TsJestTransformer } from 'ts-jest';
 
 import { NgJestCompiler } from './compiler/ng-jest-compiler';
 import { NgJestConfig } from './config/ng-jest-config';
 import { NgJestTransformer } from './ng-jest-transformer';
-
-const tr = new NgJestTransformer();
 
 jest.mock('esbuild', () => {
   return {
@@ -17,7 +16,16 @@ jest.mock('esbuild', () => {
 const mockedTransformSync = jest.mocked(transformSync);
 
 describe('NgJestTransformer', () => {
+  beforeEach(() => {
+    // @ts-expect-error testing purpose
+    TsJestTransformer._cachedConfigSets = [];
+  });
+
   test('should create NgJestCompiler and NgJestConfig instances', () => {
+    const tr = new NgJestTransformer({
+      isolatedModules: true,
+    });
+
     // @ts-expect-error testing purpose
     const cs = tr._createConfigSet({
       cwd: process.cwd(),
@@ -35,6 +43,9 @@ describe('NgJestTransformer', () => {
   });
 
   test('should not use esbuild to process js files which are not from `node_modules`', () => {
+    const tr = new NgJestTransformer({
+      isolatedModules: true,
+    });
     tr.process(
       `
       const pi = parseFloat(3.124);
@@ -48,11 +59,6 @@ describe('NgJestTransformer', () => {
           extensionsToTreatAsEsm: [],
           testMatch: [],
           testRegex: [],
-          globals: {
-            'ts-jest': {
-              isolatedModules: true,
-            },
-          },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any,
     );
@@ -61,6 +67,9 @@ describe('NgJestTransformer', () => {
   });
 
   test('should not use esbuild to process tslib file', () => {
+    const tr = new NgJestTransformer({
+      isolatedModules: true,
+    });
     tr.process(
       `
       const pi = parseFloat(3.124);
@@ -74,11 +83,6 @@ describe('NgJestTransformer', () => {
           extensionsToTreatAsEsm: [],
           testMatch: [],
           testRegex: [],
-          globals: {
-            'ts-jest': {
-              isolatedModules: true,
-            },
-          },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any,
     );
@@ -109,15 +113,15 @@ describe('NgJestTransformer', () => {
         testMatch: [],
         testRegex: [],
         globals: {
-          'ts-jest': {
-            tsconfig,
-          },
           ngJest: {
             processWithEsbuild: ['node_modules/foo.js'],
           },
         },
       },
     } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const tr = new NgJestTransformer({
+      tsconfig,
+    });
     tr.process(
       `
       const pi = parseFloat(3.124);
@@ -166,10 +170,6 @@ describe('NgJestTransformer', () => {
         testMatch: [],
         testRegex: [],
         globals: {
-          'ts-jest': {
-            tsconfig,
-            useESM: true,
-          },
           ngJest: {
             processWithEsbuild: ['node_modules/foo.js'],
           },
@@ -177,6 +177,10 @@ describe('NgJestTransformer', () => {
       },
       supportsStaticESM: true,
     } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const tr = new NgJestTransformer({
+      tsconfig,
+      useESM: true,
+    });
     tr.process(
       `
       const pi = parseFloat(3.124);

--- a/src/ng-jest-transformer.ts
+++ b/src/ng-jest-transformer.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'child_process';
 import type { TransformedSource } from '@jest/transform';
 import { LogContexts, LogLevels, type Logger, createLogger } from 'bs-logger';
 import { type ProjectConfigTsJest, type TransformOptionsTsJest, ConfigSet, TsJestTransformer } from 'ts-jest';
+import { TsJestGlobalOptions } from 'ts-jest/dist/types';
 
 import { NgJestCompiler } from './compiler/ng-jest-compiler';
 import { NgJestConfig } from './config/ng-jest-config';
@@ -16,8 +17,8 @@ export class NgJestTransformer extends TsJestTransformer {
   #ngJestLogger: Logger;
   #esbuildImpl: typeof import('esbuild');
 
-  constructor() {
-    super();
+  constructor(tsJestConfig?: TsJestGlobalOptions | undefined) {
+    super(tsJestConfig);
     this.#ngJestLogger = createLogger({
       context: {
         [LogContexts.package]: 'jest-preset-angular',

--- a/src/presets/__snapshots__/index.spec.ts.snap
+++ b/src/presets/__snapshots__/index.spec.ts.snap
@@ -4,47 +4,23 @@ exports[`Jest presets should have the correct types which come from \`ts-jest\` 
 "declare const _default: {
   defaults: {
     transformIgnorePatterns: string[];
-    transform: {
-      '^.+\\\\.(ts|js|mjs|html|svg)$': string;
-    };
-    globals: import('ts-jest').GlobalConfigTsJest;
+    transform: import('ts-jest').JestConfigWithTsJest['transform'];
     testEnvironment: string;
     moduleFileExtensions: string[];
     snapshotSerializers: string[];
   };
   defaultsESM: {
     extensionsToTreatAsEsm: string[];
-    globals: {
-      'ts-jest': {
-        useESM: boolean;
-        tsconfig?: string | boolean | import('ts-jest').RawCompilerOptions | undefined;
-        isolatedModules?: boolean | undefined;
-        compiler?: string | undefined;
-        astTransformers?: import('ts-jest').ConfigCustomTransformer | undefined;
-        diagnostics?:
-          | boolean
-          | {
-              pretty?: boolean | undefined;
-              ignoreCodes?: string | number | Array<string | number> | undefined;
-              exclude?: string[] | undefined;
-              warnOnly?: boolean | undefined;
-            }
-          | undefined;
-        babelConfig?: string | boolean | import('@babel/core').TransformOptions | undefined;
-        stringifyContentPathRegex?: string | RegExp | undefined;
-      };
-    };
     moduleNameMapper: {
       tslib: string;
     };
-    transform: {
-      '^.+\\\\.(ts|js|html|svg)$': string;
-    };
+    transform: import('ts-jest').JestConfigWithTsJest['transform'];
     transformIgnorePatterns: string[];
     testEnvironment: string;
     moduleFileExtensions: string[];
     snapshotSerializers: string[];
   };
+  defaultTransformerOptions: import('ts-jest').TsJestTransformerOptions;
 };
 export default _default;
 "
@@ -52,12 +28,6 @@ export default _default;
 
 exports[`Jest presets should return the correct jest config 1`] = `
 {
-  "globals": {
-    "ts-jest": {
-      "stringifyContentPathRegex": "\\.(html|svg)$",
-      "tsconfig": "<rootDir>/tsconfig.spec.json",
-    },
-  },
   "moduleFileExtensions": [
     "ts",
     "html",
@@ -72,7 +42,13 @@ exports[`Jest presets should return the correct jest config 1`] = `
   ],
   "testEnvironment": "jsdom",
   "transform": {
-    "^.+\\.(ts|js|mjs|html|svg)$": "jest-preset-angular",
+    "^.+\\.(ts|js|mjs|html|svg)$": [
+      "jest-preset-angular",
+      {
+        "stringifyContentPathRegex": "\\.(html|svg)$",
+        "tsconfig": "<rootDir>/tsconfig.spec.json",
+      },
+    ],
   },
   "transformIgnorePatterns": [
     "node_modules/(?!.*\\.mjs$)",
@@ -85,13 +61,6 @@ exports[`Jest presets should return the correct jest config 2`] = `
   "extensionsToTreatAsEsm": [
     ".ts",
   ],
-  "globals": {
-    "ts-jest": {
-      "stringifyContentPathRegex": "\\.(html|svg)$",
-      "tsconfig": "<rootDir>/tsconfig.spec.json",
-      "useESM": true,
-    },
-  },
   "moduleFileExtensions": [
     "ts",
     "html",
@@ -109,7 +78,14 @@ exports[`Jest presets should return the correct jest config 2`] = `
   ],
   "testEnvironment": "jsdom",
   "transform": {
-    "^.+\\.(ts|js|html|svg)$": "jest-preset-angular",
+    "^.+\\.(ts|js|html|svg)$": [
+      "jest-preset-angular",
+      {
+        "stringifyContentPathRegex": "\\.(html|svg)$",
+        "tsconfig": "<rootDir>/tsconfig.spec.json",
+        "useESM": true,
+      },
+    ],
   },
   "transformIgnorePatterns": [
     "node_modules/(?!tslib)",

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,46 +1,42 @@
-import type { ProjectConfigTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest, TsJestTransformerOptions } from 'ts-jest';
 
 import snapshotSerializers from '../serializers';
 
-const baseConfig: Pick<
-  ProjectConfigTsJest,
-  'globals' | 'testEnvironment' | 'moduleFileExtensions' | 'snapshotSerializers'
-> = {
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.(html|svg)$',
-    },
-  },
+const baseConfig: Pick<JestConfigWithTsJest, 'testEnvironment' | 'moduleFileExtensions' | 'snapshotSerializers'> = {
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['ts', 'html', 'js', 'json', 'mjs'],
   snapshotSerializers,
+};
+
+const defaultTransformerOptions: TsJestTransformerOptions = {
+  tsconfig: '<rootDir>/tsconfig.spec.json',
+  stringifyContentPathRegex: '\\.(html|svg)$',
 };
 
 const defaultPreset = {
   ...baseConfig,
   transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   transform: {
-    '^.+\\.(ts|js|mjs|html|svg)$': 'jest-preset-angular',
+    '^.+\\.(ts|js|mjs|html|svg)$': ['jest-preset-angular', defaultTransformerOptions],
   },
 };
 
 const defaultEsmPreset = {
   ...baseConfig,
   extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      ...baseConfig.globals['ts-jest'],
-      useESM: true,
-    },
-  },
   moduleNameMapper: {
     tslib: 'tslib/tslib.es6.js',
   },
   transform: {
-    '^.+\\.(ts|js|html|svg)$': 'jest-preset-angular',
+    '^.+\\.(ts|js|html|svg)$': [
+      'jest-preset-angular',
+      {
+        ...defaultTransformerOptions,
+        useESM: true,
+      },
+    ],
   },
   transformIgnorePatterns: ['node_modules/(?!tslib)'],
 };
 
-export { defaultPreset, defaultEsmPreset };
+export { defaultPreset, defaultEsmPreset, defaultTransformerOptions };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7363,7 +7363,7 @@ __metadata:
     pretty-format: ^29.0.0
     rimraf: ^3.0.2
     rxjs: ^7.5.7
-    ts-jest: ^29.0.0
+    ts-jest: ^29.0.5
     ts-node: ^10.9.1
     tslib: ^2.4.1
     typescript: ^4.8.4
@@ -10667,9 +10667,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.0.0":
-  version: 29.0.4
-  resolution: "ts-jest@npm:29.0.4"
+"ts-jest@npm:^29.0.5":
+  version: 29.0.5
+  resolution: "ts-jest@npm:29.0.5"
   dependencies:
     bs-logger: 0.x
     fast-json-stable-stringify: 2.x
@@ -10696,7 +10696,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: c3daa71835fabd0c98eefc8611edc083cd2c78cbe9a02c1edea707a907afffafc1e61051f4746c0634904d4c68cd70736d0875ae644f55c6ed8beb950bf78689
+  checksum: f60f129c2287f4c963d9ee2677132496c5c5a5d39c27ad234199a1140c26318a7d5bda34890ab0e30636ec42a8de28f84487c09e9dcec639c9c67812b3a38373
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR is my attempt at addressing #1774 and supporting Jest 29.

This migrates all `ts-jest` configs under `globals`, which is deprecated, to transformers config.
 
It also exposes a new `defaultTransformerOptions` object to allow overriding the default transformer more easily.

```js
const { defaultTransformerOptions } = require('jest-preset-angular/presets');
```

## Test plan

I linked it to one of my biggest projects running Angular 15 with 3000+ unit tests. The tests have passed with no warning.

## Does this PR introduce a breaking change?

- [X] Yes

Overriding the config via globals may not work:
```js
module.exports = {
  globals: {
    'ts-jest': {
      tsconfig: '<rootDir>/src/tsconfig.spec.json',
    },
  },
};
```

Because the preset now provides the config via the transformer, the default configuration (like `tsconfig`) takes precedence over the globals configuration.

Instead, this needs to be done (unless there is a better solution?):
```js
const { defaultTransformerOptions } = require('jest-preset-angular/presets');

module.exports = {
  ...defaultConf,
  transform: {
    '^.+\\.(ts|js|mjs|html|svg)$': [
      'jest-preset-angular',
      {
        ...defaultTransformerOptions,
        tsconfig: '<rootDir>/src/tsconfig.spec.json',
      },
    ],
  },
};
```

## Other information

Not sure if I did this right. I'm struggling to get [NgJestTransformer](https://github.com/Tommy228/jest-preset-angular/blob/main/src/ng-jest-transformer.spec.ts) unit tests to work. They are working individually but they fail when ran together. I think it has to do with some caching stuff behind `TsJestTransformer`.

[@angular-builders/jest](https://github.com/just-jeb/angular-builders) needs to be updated as well because it passes the `tsconfig` via globals, which does not work anymore.

## Todo

- [x] Investigate failing `TsJestTransformer` tests
- [x] Upgrade `ts-jest` to include this [patch](https://github.com/kulshekhar/ts-jest/pull/3966)
- [ ] Create 13.x documentation (remove changes done to 12.x)
- [ ] Update examples