### PR TITLE
Fix angular version

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Adjust your `tsconfig.spec.json` to be:
 
 Angular doesn't support native `async/await` in testing with `target` higher than `ES2016`, see https://github.com/angular/components/issues/21632#issuecomment-764975917
 
-## Migration from Angular < 13
+## Migration from Angular 13+
 
-Check out our [Migration from Angular < 13 guidance](https://thymikee.github.io/jest-preset-angular/docs/guides/angular-13+)
+Check out our [Migration from Angular 13+ guidance](https://thymikee.github.io/jest-preset-angular/docs/guides/angular-13+)
 
 ## Angular Ivy
 


### PR DESCRIPTION
Fixed the README. The text said "Angular < 13" but the article is actually about Angular >= 13, the opposite. 
