### PR TITLE
Fix: File separator issue on Windows causing error: jest: got error running globalsetup cannot find module @angular\compiler-cli

### DIFF
--- a/src/utils/ngcc-jest-processor.ts
+++ b/src/utils/ngcc-jest-processor.ts
@@ -20,13 +20,14 @@ try {
   }
 }
 function findNodeModulesDirectory(): string {
-  return ngccPath.substring(0, ngccPath.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME.replace("/", path.sep)));
+  return ngccPath.substring(0, ngccPath.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME.replace('/', path.sep)));
 }
 
 function findAngularCompilerCliVersion(): string {
-  const path = require.resolve(ANGULAR_COMPILER_CLI_PKG_NAME);
-  const substringLength = path.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME.replace("/", path.sep)) + ANGULAR_COMPILER_CLI_PKG_NAME.length;
-  const ngCompilerCliFolder = path.substring(0, substringLength);
+  const packagePath = require.resolve(ANGULAR_COMPILER_CLI_PKG_NAME);
+  const substringLength =
+    packagePath.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME.replace('/', path.sep)) + ANGULAR_COMPILER_CLI_PKG_NAME.length;
+  const ngCompilerCliFolder = packagePath.substring(0, substringLength);
   const ngCompilerCliPackageJson = `${ngCompilerCliFolder}/package.json`;
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { version } = require(ngCompilerCliPackageJson);

--- a/src/utils/ngcc-jest-processor.ts
+++ b/src/utils/ngcc-jest-processor.ts
@@ -5,7 +5,7 @@
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-const ANGULAR_COMPILER_CLI_PKG_NAME = `@angular${path.sep}compiler-cli`;
+const ANGULAR_COMPILER_CLI_PKG_NAME = '@angular/compiler-cli';
 let ngccPath = '';
 
 try {
@@ -20,12 +20,12 @@ try {
   }
 }
 function findNodeModulesDirectory(): string {
-  return ngccPath.substring(0, ngccPath.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME));
+  return ngccPath.substring(0, ngccPath.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME.replace("/", path.sep)));
 }
 
 function findAngularCompilerCliVersion(): string {
   const path = require.resolve(ANGULAR_COMPILER_CLI_PKG_NAME);
-  const substringLength = path.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME) + ANGULAR_COMPILER_CLI_PKG_NAME.length;
+  const substringLength = path.indexOf(ANGULAR_COMPILER_CLI_PKG_NAME.replace("/", path.sep)) + ANGULAR_COMPILER_CLI_PKG_NAME.length;
   const ngCompilerCliFolder = path.substring(0, substringLength);
   const ngCompilerCliPackageJson = `${ngCompilerCliFolder}/package.json`;
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This fixes #2073

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- `git clone https://github.com/pal03377/jest-preset-angular` somewhere else
- `cd jest-preset-angular` from there
- `npm install`, then `npm run build`
- `npm link` to locally link this repo
- `cd path/to/minimal-example` from here https://github.com/pal03377/minimal-jest-pathsep-issue
- `npm install`, then `npm link jest-preset-angular`
- `npm run test` to verify that it now works

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No