### PR TITLE
refactor: import zone.js/testing instead of zone-testing-bundle

### DIFF
--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,4 +1,5 @@
-require('zone.js/bundles/zone-testing-bundle.umd');
+require('zone.js');
+require('zone.js/testing');
 const { getTestBed } = require('@angular/core/testing');
 const {
   BrowserDynamicTestingModule,

--- a/setup-jest.mjs
+++ b/setup-jest.mjs
@@ -1,4 +1,5 @@
-import 'zone.js/fesm2015/zone-testing-bundle.min.js';
+import 'zone.js';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 

--- a/src/config/setup-jest.spec.ts
+++ b/src/config/setup-jest.spec.ts
@@ -1,20 +1,20 @@
 const mockInitTestEnvironment = jest.fn();
-const mockUmdZoneJs = jest.fn();
-const mockEsmZoneJs = jest.fn();
+const mockZoneJs = jest.fn();
+const mockZoneJsTesting = jest.fn();
 const mockGetTestBed = jest.fn(() => {
   return {
     initTestEnvironment: mockInitTestEnvironment,
   };
 });
-jest.mock('zone.js/bundles/zone-testing-bundle.umd', () => {
-  const mockedResult = mockUmdZoneJs();
+jest.mock('zone.js', () => {
+  const mockedResult = mockZoneJs();
 
   return {
     mockedResult,
   };
 });
-jest.mock('zone.js/fesm2015/zone-testing-bundle.min.js', () => {
-  const mockedResult = mockEsmZoneJs();
+jest.mock('zone.js/testing', () => {
+  const mockedResult = mockZoneJsTesting();
 
   return {
     mockedResult,
@@ -66,7 +66,8 @@ describe('setup-jest', () => {
 
       await import('../../setup-jest');
 
-      expect(mockUmdZoneJs).toHaveBeenCalled();
+      expect(mockZoneJs).toHaveBeenCalled();
+      expect(mockZoneJsTesting).toHaveBeenCalled();
       assertOnInitTestEnv();
       expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
         teardown: {
@@ -94,7 +95,8 @@ describe('setup-jest', () => {
 
       await import('../../setup-jest.mjs');
 
-      expect(mockEsmZoneJs).toHaveBeenCalled();
+      expect(mockZoneJs).toHaveBeenCalled();
+      expect(mockZoneJsTesting).toHaveBeenCalled();
       assertOnInitTestEnv();
       expect(mockInitTestEnvironment.mock.calls[0][2]).toEqual({
         teardown: {

--- a/website/versioned_docs/version-11.0/guides/angular-13+.md
+++ b/website/versioned_docs/version-11.0/guides/angular-13+.md
@@ -88,7 +88,8 @@ The `jest-preset-angular/setup-jest` file doesn't work with ESM, because it uses
 
 ```ts
 // setup-jest.ts
-import 'zone.js/fesm2015/zone-testing-bundle.min.js';
+import 'zone.js';
+import 'zone.js/testing';
 import './jest-global-mocks';
 
 import { getTestBed } from '@angular/core/testing';

--- a/website/versioned_docs/version-11.1/guides/angular-13+.md
+++ b/website/versioned_docs/version-11.1/guides/angular-13+.md
@@ -88,7 +88,8 @@ The `jest-preset-angular/setup-jest` file doesn't work with ESM, because it uses
 
 ```ts
 // setup-jest.ts
-import 'zone.js/fesm2015/zone-testing-bundle.min.js';
+import 'zone.js';
+import 'zone.js/testing';
 import './jest-global-mocks';
 
 import { getTestBed } from '@angular/core/testing';


### PR DESCRIPTION
Close https://github.com/thymikee/jest-preset-angular/issues/2162

From zone.js 0.13.2, the original
`zone.js/bundles/zone-testing-bundle.js` is not easily import and will eventually removed from zone.js 0.14.0.

The proper way to import zone.js and zone.js/testing is

```
import 'zone.js';
import 'zone.js/testing';
```

So this PR use this way to import zone.js related bundles.
