### PR TITLE
fix: generated id="root{n}" should be removed

### DIFF
--- a/e2e/snapshot-serializers/__tests__/__snapshots__/foo.component.spec.ts.snap
+++ b/e2e/snapshot-serializers/__tests__/__snapshots__/foo.component.spec.ts.snap
@@ -9,7 +9,9 @@ exports[`snapshot should work 1`] = `
 >
   <p>
     Line 1
-  </p><div>
+  </p><div
+    id="root0"
+  >
     <div>
        val1 
     </div>
@@ -18,13 +20,13 @@ exports[`snapshot should work 1`] = `
 `;
 
 exports[`snapshot should work 2`] = `
-<div
-  id="root0"
->
+<div>
   <p>
     Line 1
   </p>
-  <div>
+  <div
+    id="root0"
+  >
     <div>
        val1 
     </div>

--- a/e2e/snapshot-serializers/__tests__/foo.component.html
+++ b/e2e/snapshot-serializers/__tests__/foo.component.html
@@ -1,5 +1,5 @@
 <p>Line 1</p>
-<div>
+<div id="root0"><!-- this id attribute should not be eliminate -->
   <div *ngIf="condition1">
     {{ value1 }}
   </div>

--- a/src/serializers/no-ng-attributes.ts
+++ b/src/serializers/no-ng-attributes.ts
@@ -19,6 +19,15 @@ const hasAttributesToClean = (attribute: Attr): boolean =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 const serialize = (node: Element, ...rest: any): string => {
   const nodeCopy = node.cloneNode(true) as Element;
+
+  // if parent of original node is body,
+  // means the node is additionally generated when call TestBed.createComponent,
+  // this node will have id="root{n}", will cause snapshot testing not stable,
+  // so the id attribute should be removed
+  if (node.parentElement?.tagName === 'BODY') {
+    nodeCopy.removeAttribute('id');
+  }
+
   // Remove angular-specific attributes
   Object.values(nodeCopy.attributes)
     .filter(hasAttributesToRemove)


### PR DESCRIPTION
## Summary

When using snapshot testing, Angular will generate `<div id="root{n}">` root tag every time call `TestBed.createComponent`; this attribute will cause the snapshot not to be stable and should be removed when serializing content. 

## Test plan

I have updated the testing snapshot content, fixed the code, and the snapshot testing passed.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

All old snapshots containing `<div id="root{n}">` will cause failure.

So developers have to update the new snapshot manually after the upgrade.

## Other information
