### PR TITLE
feat(deps): extend version support range to Angular 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "esbuild": ">=0.13.8"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=13.0.0 <17.0.0",
-    "@angular/compiler-cli": ">=13.0.0 <17.0.0",
-    "@angular/core": ">=13.0.0 <17.0.0",
-    "@angular/platform-browser-dynamic": ">=13.0.0 <17.0.0",
+    "@angular-devkit/build-angular": ">=13.0.0 <18.0.0",
+    "@angular/compiler-cli": ">=13.0.0 <18.0.0",
+    "@angular/core": ">=13.0.0 <18.0.0",
+    "@angular/platform-browser-dynamic": ">=13.0.0 <18.0.0",
     "jest": "^29.0.0",
     "typescript": ">=4.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7728,10 +7728,10 @@ __metadata:
     typescript: ^4.9.5
     zone.js: ^0.13.0
   peerDependencies:
-    "@angular-devkit/build-angular": ">=13.0.0 <17.0.0"
-    "@angular/compiler-cli": ">=13.0.0 <17.0.0"
-    "@angular/core": ">=13.0.0 <17.0.0"
-    "@angular/platform-browser-dynamic": ">=13.0.0 <17.0.0"
+    "@angular-devkit/build-angular": ">=13.0.0 <18.0.0"
+    "@angular/compiler-cli": ">=13.0.0 <18.0.0"
+    "@angular/core": ">=13.0.0 <18.0.0"
+    "@angular/platform-browser-dynamic": ">=13.0.0 <18.0.0"
     jest: ^29.0.0
     typescript: ">=4.4"
   dependenciesMeta:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Angular 17 is being released sometime this week (Week of November 6th, 2023). This PR allows for users to install `jest-preset-angular` without getting `peerDependency` errors which cause some package managers to fail the install process.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

We've tested `jest-preset-angular` + Angular 17 as part of the Angular 17 support for [Nx](https://github.com/nrwl/nx/pull/19689) and everything works other than a peer dependency error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
