### PR TITLE
fix(transformers): handle single string styles or styleUrl property

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@
 export const TEMPLATE_URL = 'templateUrl';
 /** Angular component decorator styleUrls property name */
 export const STYLE_URLS = 'styleUrls';
+/** Angular component decorator styleUrl property name */
+export const STYLE_URL = 'styleUrl';
 /** Angular component decorator styles property name */
 export const STYLES = 'styles';
 /** Angular component decorator template property name */

--- a/src/transformers/replace-resources.ts
+++ b/src/transformers/replace-resources.ts
@@ -8,7 +8,7 @@
 import type { TsCompilerInstance } from 'ts-jest';
 import ts from 'typescript';
 
-import { STYLES, STYLE_URLS, TEMPLATE_URL, TEMPLATE, REQUIRE, COMPONENT } from '../constants';
+import { STYLES, STYLE_URLS, TEMPLATE_URL, TEMPLATE, REQUIRE, COMPONENT, STYLE_URL } from '../constants';
 
 const isAfterVersion = (targetMajor: number, targetMinor: number): boolean => {
   const [major, minor] = ts.versionMajorMinor.split('.').map((part) => parseInt(part));
@@ -225,12 +225,26 @@ function visitComponentMetadata(
       return nodeFactory.updatePropertyAssignment(node, nodeFactory.createIdentifier(TEMPLATE), importName);
 
     case STYLES:
+      if (!ts.isArrayLiteralExpression(node.initializer) && !ts.isStringLiteral(node.initializer)) {
+        return node;
+      }
+
+      return undefined;
+
     case STYLE_URLS:
       if (!ts.isArrayLiteralExpression(node.initializer)) {
         return node;
       }
 
       return undefined;
+
+    case STYLE_URL:
+      if (!ts.isStringLiteral(node.initializer)) {
+        return node;
+      }
+
+      return undefined;
+
     default:
       return node;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

With Angular v17, the `styles` property of the `Component` decorator additionally accepts a single string value instead of an array. Also, there's a new `styleUrl` property that accepts a single string value. The change was made at https://github.com/angular/angular/pull/51715.

This PR updates the transformer to handle the additional use cases and strip the properties accordingly. Without these changes, tests running over components that have those properties, fail.

## Test plan

I tested the fix as part of the Angular 17 support work in Nx. This particular PR https://github.com/nrwl/nx/pull/20146 is currently failing due to this issue. I tested the changes in this PR over those failing tests, and the failures are resolved.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
