### PR TITLE
Add extra configuration on jest.setup.js to support Ionic 6 or 7

### DIFF
--- a/website/docs/guides/angular-13+.md
+++ b/website/docs/guides/angular-13+.md
@@ -172,3 +172,25 @@ const jestConfig: Config = {
 
 export default jestConfig;
 ```
+
+### Usage with Ionic 6 or 7
+
+To support Ionic 6 or 7 you will need to modify `transformIgnorePatterns` to be as following:
+
+```js tab
+module.exports = {
+  // ...other options
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))'],
+};
+```
+
+```ts tab
+import type { Config } from 'jest';
+
+const jestConfig: Config = {
+  // ...other options
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))'],
+};
+
+export default jestConfig;
+```

--- a/website/versioned_docs/version-13.0/guides/angular-13+.md
+++ b/website/versioned_docs/version-13.0/guides/angular-13+.md
@@ -172,3 +172,25 @@ const jestConfig: Config = {
 
 export default jestConfig;
 ```
+
+### Usage with Ionic 6 or 7
+
+To support Ionic 6 or 7 you will need to modify `transformIgnorePatterns` to be as following:
+
+```js tab
+module.exports = {
+  // ...other options
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))'],
+};
+```
+
+```ts tab
+import type { Config } from 'jest';
+
+const jestConfig: Config = {
+  // ...other options
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))'],
+};
+
+export default jestConfig;
+```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

This PR adds how to fix one issue when we are having Ionic 6 or 7 Framework in the project

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We have to include this important configuration in the documentation so that all who are using Ionic 6 or 7 will avoid houuurs of investigation.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Error: 
![image](https://github.com/thymikee/jest-preset-angular/assets/13844071/1b684c25-ce13-4bd6-a71f-280ab03c1b6f)

Solution:

```js tab
module.exports = {
  // ...other options
transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))']
};
```

![image](https://github.com/thymikee/jest-preset-angular/assets/13844071/c81d8ade-e6d2-4917-9be1-68609984e012)


## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
