### PR TITLE
feat: extend version support range to Angular 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "esbuild": ">=0.15.13"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=15.0.0 <18.0.0",
-    "@angular/compiler-cli": ">=15.0.0 <18.0.0",
-    "@angular/core": ">=15.0.0 <18.0.0",
-    "@angular/platform-browser-dynamic": ">=15.0.0 <18.0.0",
+    "@angular-devkit/build-angular": ">=15.0.0 <19.0.0",
+    "@angular/compiler-cli": ">=15.0.0 <19.0.0",
+    "@angular/core": ">=15.0.0 <19.0.0",
+    "@angular/platform-browser-dynamic": ">=15.0.0 <19.0.0",
     "jest": "^29.0.0",
     "typescript": ">=4.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8003,10 +8003,10 @@ __metadata:
     typescript: "npm:^5.2.0 <5.3.0"
     zone.js: "npm:~0.14.6"
   peerDependencies:
-    "@angular-devkit/build-angular": ">=15.0.0 <18.0.0"
-    "@angular/compiler-cli": ">=15.0.0 <18.0.0"
-    "@angular/core": ">=15.0.0 <18.0.0"
-    "@angular/platform-browser-dynamic": ">=15.0.0 <18.0.0"
+    "@angular-devkit/build-angular": ">=15.0.0 <19.0.0"
+    "@angular/compiler-cli": ">=15.0.0 <19.0.0"
+    "@angular/core": ">=15.0.0 <19.0.0"
+    "@angular/platform-browser-dynamic": ">=15.0.0 <19.0.0"
     jest: ^29.0.0
     typescript: ">=4.8"
   dependenciesMeta:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Angular 18 should be [released sometime this week](https://angular.dev/reference/releases#release-schedule) (the Week of November 20th, 2024). This PR allows users to install `jest-preset-angular` without getting `peerDependency` errors, which cause some package managers to fail the installation process.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

We've tested `jest-preset-angular` + Angular 18 as part of [the Angular 18 support for Nx](https://github.com/nrwl/nx/pull/22509), and everything works other than a peer dependency error.

Additionally, I created a separate PR with a new example test application using the latest RC version of Angular 18: https://github.com/thymikee/jest-preset-angular/pull/2463. The CI checks are all passing. I'll update that PR when the stable version of Angular 18 is released.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
