### PR TITLE
refactor: deprecate legacy presets

### DIFF
--- a/presets/index.js
+++ b/presets/index.js
@@ -1,8 +1,22 @@
 const ngJestPresets = require('../build/presets');
 
 module.exports = {
-    defaults: ngJestPresets.defaultPreset,
-    defaultsESM: ngJestPresets.defaultEsmPreset,
+    get defaults() {
+        console.warn(`
+            This preset is DEPRECATED and will be removed in the future.
+            Please use "createCjsPreset" function instead. See documentation at https://thymikee.github.io/jest-preset-angular/docs/getting-started/presets#createcjspresetoptions
+        `);
+
+        return ngJestPresets.defaultPreset;
+    },
+    get defaultsESM() {
+        console.warn(`
+            This preset is DEPRECATED and will be removed in the future.
+            Please use "createCjsPreset" function instead. See documentation at https://thymikee.github.io/jest-preset-angular/docs/getting-started/presets#createesmpresetoptions
+        `);
+
+        return ngJestPresets.defaultEsmPreset;
+    },
     defaultTransformerOptions: ngJestPresets.defaultTransformerOptions,
     createCjsPreset: ngJestPresets.createCjsPreset,
     createEsmPreset: ngJestPresets.createEsmPreset,


### PR DESCRIPTION
## Summary

DEPRECATION

Using `preset: 'jest-preset-angular'` is deprecated. The recommended approach is https://thymikee.github.io/jest-preset-angular/docs/getting-started/presets#createcjspresetoptions

Using `preset: 'jest-preset-angular/presets/defaults-esm'` is deprecated. The recommended approach is https://thymikee.github.io/jest-preset-angular/docs/getting-started/presets#createesmpresetoptions

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**
