### PR TITLE
chore: 🤖 remove @angular-devkit/build-angular peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "esbuild": ">=0.15.13"
   },
   "peerDependencies": {
-    "@angular-devkit/build-angular": ">=15.0.0 <20.0.0",
     "@angular/compiler-cli": ">=15.0.0 <20.0.0",
     "@angular/core": ">=15.0.0 <20.0.0",
     "@angular/platform-browser-dynamic": ">=15.0.0 <20.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

This update ensures compatibility for projects still using Angular 18 by removing the need to explicitly list the `@angular-devkit/build-angular` dependency. This is achieved by enabling the direct use of builders from `@angular/build`. 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
