### PR TITLE
fix: properly handle types for presets module

### DIFF
--- a/presets/index.d.ts
+++ b/presets/index.d.ts
@@ -21,4 +21,4 @@ declare const _default: {
     createCjsPreset: typeof import('../build/presets').createCjsPreset;
     createEsmPreset: typeof import('../build/presets').createEsmPreset;
 };
-export default _default;
+export = _default;

--- a/src/presets/__snapshots__/index.spec.ts.snap
+++ b/src/presets/__snapshots__/index.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`Jest presets should have the correct types which come from \`ts-jest\` 
     createCjsPreset: typeof import('../build/presets').createCjsPreset;
     createEsmPreset: typeof import('../build/presets').createEsmPreset;
 };
-export default _default;
+export = _default;
 "
 `;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Since `jest-preset-angular/presets` is common js module types should be declared as `export = _defaults` instead of `export default _defaults`.

Currently require'ing reports not existing `createCjsPreset` function:

```js
const presets = require('jest-preset-angular/presets');
presets.createCjsPreset() // Property 'createCjsPreset' does not exist
```

## Test plan

Before:
```js
// jest.preset.js
const presets = require('jest-preset-angular/presets');
presets.createCjsPreset() // Property 'createCjsPreset' does not exist
```

After:

```js
// jest.preset.js
const presets = require('jest-preset-angular/presets');
presets.createCjsPreset() // Property 'createCjsPreset' exist
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->