### PR TITLE
feat: add automatic mock for angular entities (#2908)

### DIFF
--- a/e2e/automocks/__mocks__/test-manual-mock.component.ts
+++ b/e2e/automocks/__mocks__/test-manual-mock.component.ts
@@ -1,0 +1,13 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+    selector: 'test',
+    template: 'this is a manual mock for test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+})
+export class TestComponent {
+    public value = input.required<string>();
+
+    method() {}
+}

--- a/e2e/automocks/__tests__/test-automocks.ts
+++ b/e2e/automocks/__tests__/test-automocks.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import * as testManualMockComponent from '../test-manual-mock.component';
+import * as testModule from '../test.module';
+
+jest.mock('../test.module');
+jest.mock('../test-manual-mock.component');
+
+it('should mock module', () => {
+    @Component({
+        template: `
+            <test [value]="'value'">{{ 'test' | test }}</test>
+            <div test [value]="'value'">{{ 'test' | test }}</div>
+        `,
+        imports: [testModule.TestModule],
+    })
+    class TestComponent {}
+
+    jest.spyOn(console, 'error');
+
+    expect(() => TestBed.createComponent(TestComponent).detectChanges()).not.toThrow();
+
+    expect(console.error).not.toHaveBeenCalled();
+});
+
+it('should ignore modules with manual mock', () => {
+    const fixture = TestBed.createComponent(testManualMockComponent.TestComponent);
+
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.nativeElement.innerHTML).toBe('this is a manual mock for test');
+    expect(jest.isMockFunction(fixture.componentInstance.method)).toBeFalsy();
+});

--- a/e2e/automocks/external-lib/index.ts
+++ b/e2e/automocks/external-lib/index.ts
@@ -1,0 +1,3 @@
+export * from './some.service';
+export * from './some.component';
+export * from './some.pipe';

--- a/e2e/automocks/external-lib/some.component.ts
+++ b/e2e/automocks/external-lib/some.component.ts
@@ -1,0 +1,11 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+    selector: 'some',
+    template: ``,
+})
+export class SomeComponent {
+    public readonly value = input.required<string>();
+
+    public readonly helloWorld = output();
+}

--- a/e2e/automocks/external-lib/some.pipe.ts
+++ b/e2e/automocks/external-lib/some.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'some',
+})
+export class SomePipe implements PipeTransform {
+    public transform(value: string): string {
+        return value.toUpperCase();
+    }
+}

--- a/e2e/automocks/external-lib/some.service.ts
+++ b/e2e/automocks/external-lib/some.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class SomeService {
+    public doSomething(): void {}
+}

--- a/e2e/automocks/jest-cjs.config.ts
+++ b/e2e/automocks/jest-cjs.config.ts
@@ -1,0 +1,23 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+    displayName: 'e2e-automocks',
+    testEnvironment: 'jsdom',
+    setupFilesAfterEnv: ['<rootDir>/../setup-test-env.ts', '<rootDir>/setup-test-env.ts'],
+    transform: {
+        '^.+\\.(ts|mjs|js|html)$': [
+            '<rootDir>/../../build/index.js',
+            {
+                babelConfig: true,
+                tsconfig: '<rootDir>/tsconfig-cjs.spec.json',
+                stringifyContentPathRegex: '\\.(html|svg)$',
+            },
+        ],
+    },
+    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+    moduleNameMapper: {
+        '^external-lib$': '<rootDir>/external-lib/index.ts',
+    },
+};
+
+export default config;

--- a/e2e/automocks/jest-esm.config.ts
+++ b/e2e/automocks/jest-esm.config.ts
@@ -1,0 +1,22 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+    displayName: 'e2e-automocks',
+    extensionsToTreatAsEsm: ['.ts', '.mts'],
+    setupFilesAfterEnv: ['<rootDir>/../setup-test-env.mts', '<rootDir>/setup-test-env.mts'],
+    transform: {
+        '^.+\\.(ts|mts|mjs|js|html)$': [
+            '<rootDir>/../../build/index.js',
+            {
+                babelConfig: true,
+                useESM: true,
+                tsconfig: '<rootDir>/tsconfig-esm.spec.json',
+            },
+        ],
+    },
+    moduleNameMapper: {
+        '^external-lib$': '<rootDir>/external-lib/index.ts',
+    },
+};
+
+export default config;

--- a/e2e/automocks/jest-transpile-cjs.config.ts
+++ b/e2e/automocks/jest-transpile-cjs.config.ts
@@ -1,0 +1,23 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+    displayName: 'e2e-automocks',
+    testEnvironment: 'jsdom',
+    setupFilesAfterEnv: ['<rootDir>/../setup-test-env.ts', '<rootDir>/setup-test-env.ts'],
+    transform: {
+        '^.+\\.(ts|mjs|js|html)$': [
+            '<rootDir>/../../build/index.js',
+            {
+                babelConfig: true,
+                tsconfig: '<rootDir>/tsconfig-transpile-cjs.spec.json',
+                stringifyContentPathRegex: '\\.(html|svg)$',
+            },
+        ],
+    },
+    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+    moduleNameMapper: {
+        '^external-lib$': '<rootDir>/external-lib/index.ts',
+    },
+};
+
+export default config;

--- a/e2e/automocks/jest-transpile-esm.config.ts
+++ b/e2e/automocks/jest-transpile-esm.config.ts
@@ -1,0 +1,22 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+    displayName: 'e2e-automocks',
+    extensionsToTreatAsEsm: ['.ts', '.mts'],
+    setupFilesAfterEnv: ['<rootDir>/../setup-test-env.mts', '<rootDir>/setup-test-env.mts'],
+    transform: {
+        '^.+\\.(ts|mts|mjs|js|html)$': [
+            '<rootDir>/../../build/index.js',
+            {
+                babelConfig: true,
+                useESM: true,
+                tsconfig: '<rootDir>/tsconfig-transpile-esm.spec.json',
+            },
+        ],
+    },
+    moduleNameMapper: {
+        '^external-lib$': '<rootDir>/external-lib/index.ts',
+    },
+};
+
+export default config;

--- a/e2e/automocks/mock-component-example/my.component.spec.ts
+++ b/e2e/automocks/mock-component-example/my.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SomeComponent } from 'external-lib';
+
+import { MyComponent } from './my.component';
+
+jest.mock('external-lib');
+
+describe('MyComponent', () => {
+    let fixture: ComponentFixture<MyComponent>;
+    let component: MyComponent;
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(MyComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    describe('if isVisible is true', () => {
+        beforeEach(() => {
+            fixture.componentRef.setInput('isVisible', true);
+            fixture.detectChanges();
+        });
+
+        it('should render SomeComponent', () => {
+            expect(fixture.debugElement.query(By.directive(SomeComponent))).toBeTruthy();
+        });
+
+        describe('on helloWorld event', () => {
+            beforeEach(() => {
+                jest.spyOn(component, 'onHelloWorld');
+
+                fixture.debugElement.query(By.directive(SomeComponent)).triggerEventHandler('helloWorld', 'hello');
+            });
+
+            it('should call onHelloWorld', () => {
+                expect(component.onHelloWorld).toHaveBeenCalledWith('hello');
+            });
+        });
+    });
+
+    describe('if isVisible is false', () => {
+        beforeEach(() => {
+            fixture.componentRef.setInput('isVisible', false);
+            fixture.detectChanges();
+        });
+
+        it('should not render SomeComponent', () => {
+            expect(fixture.debugElement.query(By.directive(SomeComponent))).toBeFalsy();
+        });
+    });
+});

--- a/e2e/automocks/mock-component-example/my.component.ts
+++ b/e2e/automocks/mock-component-example/my.component.ts
@@ -1,0 +1,20 @@
+import { Component, input, signal } from '@angular/core';
+import { SomeComponent } from 'external-lib';
+
+@Component({
+    selector: 'my',
+    template: `
+        @if (isVisible()) {
+            <some [value]="value()" (helloWorld)="onHelloWorld($event)" />
+        }
+    `,
+    imports: [SomeComponent],
+})
+export class MyComponent {
+    public readonly isVisible = input(false);
+    public readonly value = signal('');
+
+    public onHelloWorld(data: string): void {
+        console.log(data);
+    }
+}

--- a/e2e/automocks/mock-pipe-example/my.component.spec.ts
+++ b/e2e/automocks/mock-pipe-example/my.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SomePipe } from 'external-lib';
+
+import { MyComponent } from './my.component';
+
+jest.mock('external-lib');
+
+describe('MyComponent', () => {
+    let fixture: ComponentFixture<MyComponent>;
+    let component: MyComponent;
+
+    beforeEach(() => {
+        jest.mocked(SomePipe).prototype.transform.mockReturnValue('transformed');
+
+        fixture = TestBed.createComponent(MyComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should render transformed value', () => {
+        expect(fixture.nativeElement.textContent).toBe('transformed');
+    });
+
+    describe('if value changes', () => {
+        beforeEach(() => {
+            component.value.set('new value');
+            jest.mocked(SomePipe).prototype.transform.mockReturnValue('new transformed');
+            fixture.detectChanges();
+        });
+
+        it('should render new transformed value', () => {
+            expect(fixture.nativeElement.textContent).toBe('new transformed');
+        });
+    });
+});

--- a/e2e/automocks/mock-pipe-example/my.component.ts
+++ b/e2e/automocks/mock-pipe-example/my.component.ts
@@ -1,0 +1,11 @@
+import { Component, signal } from '@angular/core';
+import { SomePipe } from 'external-lib';
+
+@Component({
+    selector: 'my',
+    template: ` <p>{{ value() | some }}</p> `,
+    imports: [SomePipe],
+})
+export class MyComponent {
+    public readonly value = signal('');
+}

--- a/e2e/automocks/mock-service-example/my.component.spec.ts
+++ b/e2e/automocks/mock-service-example/my.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SomeService } from 'external-lib';
+
+import { MyComponent } from './my.component';
+
+jest.mock('external-lib');
+
+describe('MyComponent', () => {
+    let fixture: ComponentFixture<MyComponent>;
+    let someService: jest.Mocked<SomeService>;
+
+    beforeEach(() => {
+        someService = jest.mocked(TestBed.inject(SomeService));
+
+        fixture = TestBed.createComponent(MyComponent);
+        fixture.detectChanges();
+    });
+
+    describe('on button click', () => {
+        beforeEach(() => {
+            fixture.debugElement.query(By.css('button')).triggerEventHandler('click', null);
+        });
+
+        it('should call doSomething on SomeService', () => {
+            expect(someService.doSomething).toHaveBeenCalled();
+        });
+    });
+});

--- a/e2e/automocks/mock-service-example/my.component.ts
+++ b/e2e/automocks/mock-service-example/my.component.ts
@@ -1,0 +1,14 @@
+import { Component, inject } from '@angular/core';
+import { SomeService } from 'external-lib';
+
+@Component({
+    selector: 'my',
+    template: `<button (click)="onButtonClick()">Click me</button>`,
+})
+export class MyComponent {
+    private readonly someService = inject(SomeService);
+
+    public onButtonClick(): void {
+        this.someService.doSomething();
+    }
+}

--- a/e2e/automocks/setup-test-env.mts
+++ b/e2e/automocks/setup-test-env.mts
@@ -1,0 +1,3 @@
+import { setupAutoMocks } from '../../setup-env/automocks.mjs';
+
+setupAutoMocks();

--- a/e2e/automocks/setup-test-env.ts
+++ b/e2e/automocks/setup-test-env.ts
@@ -1,0 +1,3 @@
+import { setupAutoMocks } from '../../setup-env/automocks.js';
+
+setupAutoMocks();

--- a/e2e/automocks/test-manual-mock.component.ts
+++ b/e2e/automocks/test-manual-mock.component.ts
@@ -1,0 +1,13 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+})
+export class TestComponent {
+    public value = input.required<string>();
+
+    method() {}
+}

--- a/e2e/automocks/test.component.ts
+++ b/e2e/automocks/test.component.ts
@@ -1,0 +1,13 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+})
+export class TestComponent {
+    public value = input.required<string>();
+
+    method() {}
+}

--- a/e2e/automocks/test.directive.ts
+++ b/e2e/automocks/test.directive.ts
@@ -1,0 +1,11 @@
+import { Directive, input } from '@angular/core';
+
+@Directive({
+    selector: '[test]',
+    standalone: true,
+})
+export class TestDirective {
+    public value = input.required<string>();
+
+    method() {}
+}

--- a/e2e/automocks/test.module.ts
+++ b/e2e/automocks/test.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { TestComponent } from './test.component';
+import { TestDirective } from './test.directive';
+import { TestPipe } from './test.pipe';
+
+@NgModule({
+    imports: [TestComponent, TestDirective, TestPipe],
+    exports: [TestComponent, TestDirective, TestPipe],
+})
+export class TestModule {}

--- a/e2e/automocks/test.pipe.ts
+++ b/e2e/automocks/test.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'test',
+})
+export class TestPipe implements PipeTransform {
+    public transform(value: string): string {
+        return `test ${value}`;
+    }
+}

--- a/e2e/automocks/tsconfig-base.spec.json
+++ b/e2e/automocks/tsconfig-base.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig-base.spec.json",
+  "compilerOptions": {
+    "isolatedModules": false,
+    "paths": {
+      "external-lib": ["e2e/automocks/external-lib/index.ts"]
+    }
+  },
+  "include": ["**/*.ts"]
+}

--- a/e2e/automocks/tsconfig-cjs.spec.json
+++ b/e2e/automocks/tsconfig-cjs.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-base.spec.json",
+  "compilerOptions": {
+    "isolatedModules": false
+  }
+}

--- a/e2e/automocks/tsconfig-esm.spec.json
+++ b/e2e/automocks/tsconfig-esm.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-base.spec.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "esModuleInterop": true,
+    "isolatedModules": false
+  }
+}

--- a/e2e/automocks/tsconfig-transpile-cjs.spec.json
+++ b/e2e/automocks/tsconfig-transpile-cjs.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-cjs.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/e2e/automocks/tsconfig-transpile-esm.spec.json
+++ b/e2e/automocks/tsconfig-transpile-esm.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-esm.spec.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,8 @@ const config: Config = {
             },
         ],
     },
+    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+    setupFilesAfterEnv: ['<rootDir>/setup-test-env.ts'],
 };
 
 export default config;

--- a/setup-env/automocks.d.mts
+++ b/setup-env/automocks.d.mts
@@ -1,0 +1,1 @@
+export declare const setupAutoMocks: () => void;

--- a/setup-env/automocks.d.ts
+++ b/setup-env/automocks.d.ts
@@ -1,0 +1,4 @@
+declare const _default: {
+    setupAutoMocks: () => void;
+};
+export = _default;

--- a/setup-env/automocks.js
+++ b/setup-env/automocks.js
@@ -1,0 +1,3 @@
+const { setupAutoMocks } = require('../build/automocks/setup-auto-mocks');
+
+module.exports = { setupAutoMocks };

--- a/setup-env/automocks.mjs
+++ b/setup-env/automocks.mjs
@@ -1,0 +1,1 @@
+export { setupAutoMocks } from '../build/automocks/setup-auto-mocks.js';

--- a/setup-test-env.ts
+++ b/setup-test-env.ts
@@ -1,0 +1,3 @@
+import { setupZonelessTestEnv } from './setup-env/zoneless';
+
+setupZonelessTestEnv();

--- a/src/automocks/__fixtures__/non-root.service.ts
+++ b/src/automocks/__fixtures__/non-root.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class NonRootService {
+    method() {}
+}

--- a/src/automocks/__fixtures__/root.service.ts
+++ b/src/automocks/__fixtures__/root.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class RootService {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-not-standalone.component.ts
+++ b/src/automocks/__fixtures__/test-not-standalone.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: false,
+    styles: [':host { display: block; }'],
+})
+export class TestComponent {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-not-standalone.directive.ts
+++ b/src/automocks/__fixtures__/test-not-standalone.directive.ts
@@ -1,0 +1,9 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+    selector: '[test]',
+    standalone: false,
+})
+export class TestDirective {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-not-standalone.module.ts
+++ b/src/automocks/__fixtures__/test-not-standalone.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { TestComponent } from './test-not-standalone.component';
+import { TestDirective } from './test-not-standalone.directive';
+import { TestPipe } from './test-not-standalone.pipe';
+
+@NgModule({
+    declarations: [TestComponent, TestPipe, TestDirective],
+    exports: [TestComponent, TestPipe, TestDirective],
+})
+export class TestModule {}

--- a/src/automocks/__fixtures__/test-not-standalone.pipe.ts
+++ b/src/automocks/__fixtures__/test-not-standalone.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'test',
+    standalone: false,
+})
+export class TestPipe implements PipeTransform {
+    public transform(value: string): string {
+        return `test ${value}`;
+    }
+}

--- a/src/automocks/__fixtures__/test-with-host-directives-with-signal-inputs.component.ts
+++ b/src/automocks/__fixtures__/test-with-host-directives-with-signal-inputs.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+
+import { TestDirective } from './test-with-signal-inputs.directive';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+    hostDirectives: [
+        {
+            directive: TestDirective,
+            inputs: ['value1', 'value2', 'aValue3', 'aValue4'],
+        },
+    ],
+})
+export class TestComponent {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-with-host-directives-with-signal-inputs.directive.ts
+++ b/src/automocks/__fixtures__/test-with-host-directives-with-signal-inputs.directive.ts
@@ -1,0 +1,17 @@
+import { Directive } from '@angular/core';
+
+import { TestDirective as TestDirectiveSimple } from './test-with-signal-inputs.directive';
+
+@Directive({
+    selector: '[test]',
+    standalone: true,
+    hostDirectives: [
+        {
+            directive: TestDirectiveSimple,
+            inputs: ['value1', 'value2', 'aValue3', 'aValue4'],
+        },
+    ],
+})
+export class TestDirective {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-with-host-directives.component.ts
+++ b/src/automocks/__fixtures__/test-with-host-directives.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+import { TestDirective } from './test.directive';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+    hostDirectives: [TestDirective],
+})
+export class TestComponent {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-with-host-directives.directive.ts
+++ b/src/automocks/__fixtures__/test-with-host-directives.directive.ts
@@ -1,0 +1,12 @@
+import { Directive } from '@angular/core';
+
+import { TestDirective as TestDirectiveSimple } from './test.directive';
+
+@Directive({
+    selector: '[test]',
+    standalone: true,
+    hostDirectives: [TestDirectiveSimple],
+})
+export class TestDirective {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-with-signal-inputs.component.ts
+++ b/src/automocks/__fixtures__/test-with-signal-inputs.component.ts
@@ -1,0 +1,20 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+})
+export class TestComponent {
+    public readonly value1 = input('');
+    public readonly value2 = input.required<string>();
+    public readonly value3 = input('', {
+        alias: 'aValue3',
+    });
+    public readonly value4 = input.required({
+        alias: 'aValue4',
+    });
+
+    method() {}
+}

--- a/src/automocks/__fixtures__/test-with-signal-inputs.directive.ts
+++ b/src/automocks/__fixtures__/test-with-signal-inputs.directive.ts
@@ -1,0 +1,18 @@
+import { Directive, input } from '@angular/core';
+
+@Directive({
+    selector: '[test]',
+    standalone: true,
+})
+export class TestDirective {
+    public readonly value1 = input('');
+    public readonly value2 = input.required<string>();
+    public readonly value3 = input('', {
+        alias: 'aValue3',
+    });
+    public readonly value4 = input.required({
+        alias: 'aValue4',
+    });
+
+    method() {}
+}

--- a/src/automocks/__fixtures__/test.component.ts
+++ b/src/automocks/__fixtures__/test.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'test',
+    template: 'this is a test',
+    standalone: true,
+    styles: [':host { display: block; }'],
+})
+export class TestComponent {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test.directive.ts
+++ b/src/automocks/__fixtures__/test.directive.ts
@@ -1,0 +1,9 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+    selector: '[test]',
+    standalone: true,
+})
+export class TestDirective {
+    method() {}
+}

--- a/src/automocks/__fixtures__/test.module.ts
+++ b/src/automocks/__fixtures__/test.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { TestComponent } from './test.component';
+import { TestDirective } from './test.directive';
+import { TestPipe } from './test.pipe';
+
+@NgModule({
+    imports: [TestComponent, TestDirective, TestPipe],
+    exports: [TestComponent, TestDirective, TestPipe],
+})
+export class TestModule {}

--- a/src/automocks/__fixtures__/test.pipe.ts
+++ b/src/automocks/__fixtures__/test.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'test',
+})
+export class TestPipe implements PipeTransform {
+    public transform(value: string): string {
+        return `test ${value}`;
+    }
+}

--- a/src/automocks/setup-auto-mocks.ts
+++ b/src/automocks/setup-auto-mocks.ts
@@ -1,0 +1,20 @@
+import { version } from 'jest/package.json';
+
+import { stubAnything } from './stub-anything';
+import { StubCache } from './stub-cache';
+
+export function setupAutoMocks(): void {
+    const cache = new StubCache();
+
+    if (Number(version.split('.')[0]) < 30) {
+        throw new Error('This function requires `jest>=30`. Please upgrade jest package.');
+    }
+
+    jest.onGenerateMock((modulePath: string, moduleMock: unknown) => {
+        const moduleActual = jest.requireActual(modulePath);
+
+        stubAnything(cache, moduleActual, moduleMock);
+
+        return moduleMock;
+    });
+}

--- a/src/automocks/stub-anything.spec.ts
+++ b/src/automocks/stub-anything.spec.ts
@@ -1,0 +1,114 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { stubAnything } from './stub-anything';
+import { StubCache } from './stub-cache';
+
+const wrappers = [
+    (value: unknown) => value,
+    (value: unknown) => [value],
+    (value: unknown) => ({ value }),
+    (value: unknown) => [{ value }],
+];
+
+describe('stubAnything', () => {
+    it.each(wrappers)('should stub root service', (wrap) => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/root.service')>('./__fixtures__/root.service');
+        const mock =
+            jest.createMockFromModule<typeof import('./__fixtures__/root.service')>('./__fixtures__/root.service');
+
+        const cache = new StubCache();
+
+        stubAnything(cache, wrap(actual.RootService), wrap(mock.RootService));
+
+        const service = TestBed.inject(mock.RootService);
+
+        expect(jest.isMockFunction(service.method)).toBeTruthy();
+    });
+
+    it.each(wrappers)('should stub pipe', (wrap) => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test.pipe')>('./__fixtures__/test.pipe');
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test.pipe')>('./__fixtures__/test.pipe');
+
+        const cache = new StubCache();
+
+        stubAnything(cache, wrap(actual.TestPipe), wrap(mock.TestPipe));
+
+        @Component({
+            template: '{{value() | test}}',
+            imports: [mock.TestPipe],
+        })
+        class RootComponent {
+            public readonly value = signal('value');
+        }
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        expect(root.debugElement.nativeElement.innerHTML).toBe('');
+
+        root.componentInstance.value.set('test');
+        jest.mocked(mock.TestPipe.prototype.transform).mockImplementation(() => 'stub value');
+
+        root.detectChanges();
+
+        expect(root.debugElement.nativeElement.innerHTML).toBe('stub value');
+    });
+
+    it.each(wrappers)('stub directive with host directives that have inputs', (wrap) => {
+        const actual = jest.requireActual<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.directive');
+        const mock = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.directive');
+
+        const cache = new StubCache();
+
+        stubAnything(cache, wrap(actual.TestDirective), wrap(mock.TestDirective));
+
+        @Component({
+            template: '<div test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it.each(wrappers)('stub component with signal inputs', (wrap) => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-signal-inputs.component')>(
+            './__fixtures__/test-with-signal-inputs.component',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-signal-inputs.component')>(
+            './__fixtures__/test-with-signal-inputs.component',
+        );
+
+        const cache = new StubCache();
+
+        stubAnything(cache, wrap(actual.TestComponent), wrap(mock.TestComponent));
+
+        @Component({
+            template: '<test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+});

--- a/src/automocks/stub-anything.ts
+++ b/src/automocks/stub-anything.ts
@@ -1,0 +1,81 @@
+import { StubCache } from './stub-cache';
+import { stubComponent } from './stub-component';
+import { stubDirective } from './stub-directive';
+import { stubInjectable } from './stub-injectable';
+import { stubModule } from './stub-module';
+import { stubPipe } from './stub-pipe';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+    return typeof value === 'function';
+}
+
+function isFunctionOrRecord(value: unknown): value is ((...args: unknown[]) => unknown) | Record<string, unknown> {
+    return isFunction(value) || isRecord(value);
+}
+
+function isConstructor(value: unknown): value is new (...args: unknown[]) => unknown {
+    return (
+        typeof value === 'function' &&
+        typeof value.prototype === 'object' &&
+        value.prototype !== null &&
+        value.prototype.constructor === value
+    );
+}
+
+function* walk<T>(
+    actual: T,
+    mock: T,
+    walkedNodes: unknown[] = [],
+): Generator<[actual: new (...args: unknown[]) => unknown, mock: new (...args: unknown[]) => unknown]> {
+    if (!isFunctionOrRecord(actual) || !isFunctionOrRecord(mock) || walkedNodes.includes(actual)) {
+        return;
+    }
+
+    const keys = Object.getOwnPropertyNames(actual) as (string & keyof T)[];
+
+    if (isConstructor(actual) && isConstructor(mock) && keys.some((key) => key.startsWith('ɵ'))) {
+        yield [actual, mock];
+
+        return;
+    }
+
+    for (const key of Object.getOwnPropertyNames(actual) as (string & keyof T)[]) {
+        if (!Reflect.has(actual, key)) {
+            continue;
+        }
+
+        try {
+            yield* walk(Reflect.get(actual, key), Reflect.get(mock, key), [...walkedNodes, actual]);
+        } catch {
+            // pass
+        }
+    }
+}
+
+export function stubAnything<T>(cache: StubCache, actual: T, mock: T): void {
+    for (const [actualCtor, mockCtor] of walk(actual, mock)) {
+        if ('ɵprov' in actualCtor) {
+            stubInjectable(cache, actualCtor, mockCtor);
+        }
+
+        if ('ɵcmp' in actualCtor) {
+            stubComponent(cache, actualCtor, mockCtor);
+        }
+
+        if ('ɵdir' in actualCtor) {
+            stubDirective(cache, actualCtor, mockCtor);
+        }
+
+        if ('ɵpipe' in actualCtor) {
+            stubPipe(cache, actualCtor, mockCtor);
+        }
+
+        if ('ɵmod' in actualCtor) {
+            stubModule(cache, actualCtor, mockCtor);
+        }
+    }
+}

--- a/src/automocks/stub-cache.ts
+++ b/src/automocks/stub-cache.ts
@@ -1,0 +1,49 @@
+import { Type, ɵComponentDef, ɵDirectiveDef, ɵNgModuleDef, ɵPipeDef } from '@angular/core';
+
+export class StubCache {
+    private readonly componentsCache = new WeakMap<Type<unknown>, ɵComponentDef<unknown>>();
+    private readonly directivesCache = new WeakMap<Type<unknown>, ɵDirectiveDef<unknown>>();
+    private readonly pipesCache = new WeakMap<Type<unknown>, ɵPipeDef<unknown>>();
+    private readonly modulesCache = new WeakMap<Type<unknown>, ɵNgModuleDef<unknown>>();
+    private readonly mocks = new WeakMap<Type<unknown>, Type<unknown>>();
+
+    public getOrCreateComponentDef<T>(actual: Type<T>, notFoundValueFactory: () => ɵComponentDef<T>): ɵComponentDef<T> {
+        if (!this.componentsCache.has(actual)) {
+            this.componentsCache.set(actual, notFoundValueFactory());
+        }
+
+        return this.componentsCache.get(actual) as ɵComponentDef<T>;
+    }
+
+    public getOrCreateDirectiveDef<T>(actual: Type<T>, notFoundValueFactory: () => ɵDirectiveDef<T>): ɵDirectiveDef<T> {
+        if (!this.directivesCache.has(actual)) {
+            this.directivesCache.set(actual, notFoundValueFactory());
+        }
+
+        return this.directivesCache.get(actual) as ɵDirectiveDef<T>;
+    }
+
+    public getOrCreatePipeDef<T>(actual: Type<T>, notFoundValueFactory: () => ɵPipeDef<T>): ɵPipeDef<T> {
+        if (!this.pipesCache.has(actual)) {
+            this.pipesCache.set(actual, notFoundValueFactory());
+        }
+
+        return this.pipesCache.get(actual) as ɵPipeDef<T>;
+    }
+
+    public getOrCreateModuleDef<T>(actual: Type<T>, notFoundValueFactory: () => ɵNgModuleDef<T>): ɵNgModuleDef<T> {
+        if (!this.modulesCache.has(actual)) {
+            this.modulesCache.set(actual, notFoundValueFactory());
+        }
+
+        return this.modulesCache.get(actual) as ɵNgModuleDef<T>;
+    }
+
+    public getMock<T>(actual: Type<T>, notFoundValueFactory: () => Type<T>): Type<T> {
+        return (this.mocks.get(actual) as Type<T>) ?? notFoundValueFactory();
+    }
+
+    public setMock<T>(actual: Type<T>, mock: Type<T>): void {
+        this.mocks.set(actual, mock);
+    }
+}

--- a/src/automocks/stub-component.spec.ts
+++ b/src/automocks/stub-component.spec.ts
@@ -1,0 +1,214 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { StubCache } from './stub-cache';
+import { stubComponent } from './stub-component';
+import { stubDirective } from './stub-directive';
+
+describe('stubComponent', () => {
+    it('stub simple component', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test.component')>(
+            './__fixtures__/test.component',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test.component')>(
+            './__fixtures__/test.component',
+        );
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock.TestComponent);
+
+        @Component({
+            template: '<test></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testComponent = root.debugElement.query(By.directive(mock.TestComponent));
+
+        expect(testComponent.componentInstance).toBeInstanceOf(mock.TestComponent);
+        expect(testComponent.nativeElement.innerHTML).toBe('');
+    });
+
+    it('reuse stubbed component', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test.component')>(
+            './__fixtures__/test.component',
+        );
+        const mock1 = jest.createMockFromModule<Readonly<typeof import('./__fixtures__/test.component')>>(
+            './__fixtures__/test.component',
+        );
+        const mock2 = jest.createMockFromModule<Readonly<typeof import('./__fixtures__/test.component')>>(
+            './__fixtures__/test.component',
+        );
+
+        expect(mock1).not.toBe(mock2);
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock1.TestComponent);
+        stubComponent(cache, actual.TestComponent, mock2.TestComponent);
+
+        expect(mock1.TestComponent.ɵcmp).toBe(mock2.TestComponent.ɵcmp);
+    });
+
+    it('stub component with host directives', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-host-directives.component')>(
+            './__fixtures__/test-with-host-directives.component',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-host-directives.component')>(
+            './__fixtures__/test-with-host-directives.component',
+        );
+        const actualDirective = jest.requireActual<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+        const mockDirective = jest.createMockFromModule<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock.TestComponent);
+        stubDirective(cache, actualDirective.TestDirective, mockDirective.TestDirective);
+
+        @Component({
+            template: '<test></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testComponent = root.debugElement.query(By.directive(mockDirective.TestDirective));
+
+        expect(testComponent.componentInstance).toBeInstanceOf(mock.TestComponent);
+        expect(testComponent.injector.get(mockDirective.TestDirective)).toBeTruthy();
+    });
+
+    it('stub component with host directives that not imported', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-host-directives.component')>(
+            './__fixtures__/test-with-host-directives.component',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-host-directives.component')>(
+            './__fixtures__/test-with-host-directives.component',
+        );
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock.TestComponent);
+
+        @Component({
+            template: '<test></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testComponent = root.debugElement.query(By.directive(mock.TestComponent));
+
+        expect(testComponent.componentInstance).toBeInstanceOf(mock.TestComponent);
+    });
+
+    it('stub component with signal inputs', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-signal-inputs.component')>(
+            './__fixtures__/test-with-signal-inputs.component',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-signal-inputs.component')>(
+            './__fixtures__/test-with-signal-inputs.component',
+        );
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock.TestComponent);
+
+        @Component({
+            template: '<test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('stub component with host directives that have inputs', () => {
+        const actual = jest.requireActual<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.component')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.component');
+        const mock = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.component')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.component');
+        const actualHostDirective = jest.requireActual<
+            typeof import('./__fixtures__/test-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-signal-inputs.directive');
+        const mockHostDirective = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-signal-inputs.directive');
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock.TestComponent);
+        stubDirective(cache, actualHostDirective.TestDirective, mockHostDirective.TestDirective);
+
+        @Component({
+            template: '<test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('stub component with host directives that have inputs and not imported', () => {
+        const actual = jest.requireActual<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.component')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.component');
+        const mock = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.component')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.component');
+
+        const cache = new StubCache();
+
+        stubComponent(cache, actual.TestComponent, mock.TestComponent);
+
+        @Component({
+            template: '<test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></test>',
+            imports: [mock.TestComponent],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+});

--- a/src/automocks/stub-component.ts
+++ b/src/automocks/stub-component.ts
@@ -1,0 +1,48 @@
+import { Type, ɵComponentDef, ɵɵdefineComponent } from '@angular/core';
+
+import type { StubCache } from './stub-cache';
+import { stubHostDirectives } from './stub-host-directives';
+import { stubInputsFactory } from './stub-inputs-factory';
+import { ComponentType } from './types';
+
+export function stubComponent<T>(cache: StubCache, actual: Type<T>, mock: Type<T>): asserts mock is ComponentType<T> {
+    const { selectors, exportAs, standalone, signals, ngContentSelectors, hostDirectives, inputs, inputConfig } = (
+        actual as ComponentType<T>
+    ).ɵcmp;
+
+    cache.setMock(actual, mock);
+
+    Object.defineProperty(mock, 'ɵcmp', {
+        get(): ɵComponentDef<T> {
+            return cache.getOrCreateComponentDef(actual, () => {
+                const features: never[] = [];
+
+                stubHostDirectives(cache, hostDirectives, features);
+
+                return ɵɵdefineComponent({
+                    type: mock,
+                    selectors,
+                    inputs: inputConfig,
+                    outputs: {},
+                    exportAs: exportAs ?? undefined,
+                    standalone,
+                    signals,
+                    decls: 0,
+                    vars: 0,
+                    template: () => {},
+                    ngContentSelectors,
+                    hostAttrs: ['stub-component', Math.random()],
+                    features,
+                });
+            });
+        },
+    });
+
+    let factory = () => new mock();
+
+    factory = stubInputsFactory(factory, inputs);
+
+    Object.defineProperty(mock, 'ɵfac', {
+        value: factory,
+    });
+}

--- a/src/automocks/stub-constructor.ts
+++ b/src/automocks/stub-constructor.ts
@@ -1,0 +1,21 @@
+import { Type } from '@angular/core';
+
+import { StubCache } from './stub-cache';
+
+export function stubConstructor<T>(
+    cache: StubCache,
+    actual: Type<T>,
+    stubFn: (cache: StubCache, actual: Type<T>, mock: Type<T>) => void,
+): Type<T> {
+    const mock = jest.fn() as Type<T>;
+
+    for (const key of Object.getOwnPropertyNames(actual.prototype)) {
+        if (key !== 'constructor' && typeof actual.prototype[key] === 'function') {
+            mock.prototype[key] = jest.fn();
+        }
+    }
+
+    stubFn(cache, actual, mock);
+
+    return mock;
+}

--- a/src/automocks/stub-directive.spec.ts
+++ b/src/automocks/stub-directive.spec.ts
@@ -1,0 +1,212 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { StubCache } from './stub-cache';
+import { stubDirective } from './stub-directive';
+
+describe('stubDirective', () => {
+    it('stub simple directive', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock.TestDirective);
+
+        @Component({
+            template: '<div test></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testDirective = root.debugElement.query(By.directive(mock.TestDirective));
+
+        expect(testDirective.injector.get(mock.TestDirective)).toBeTruthy();
+    });
+
+    it('reuse stubbed directive', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+        const mock1 = jest.createMockFromModule<Readonly<typeof import('./__fixtures__/test.directive')>>(
+            './__fixtures__/test.directive',
+        );
+        const mock2 = jest.createMockFromModule<Readonly<typeof import('./__fixtures__/test.directive')>>(
+            './__fixtures__/test.directive',
+        );
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock1.TestDirective);
+        stubDirective(cache, actual.TestDirective, mock2.TestDirective);
+
+        expect(mock1.TestDirective.ɵdir).toBe(mock2.TestDirective.ɵdir);
+    });
+
+    it('stub directive with host directives', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-host-directives.directive')>(
+            './__fixtures__/test-with-host-directives.directive',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-host-directives.directive')>(
+            './__fixtures__/test-with-host-directives.directive',
+        );
+        const actualHostDirective = jest.requireActual<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+        const mockHostDirective = jest.createMockFromModule<typeof import('./__fixtures__/test.directive')>(
+            './__fixtures__/test.directive',
+        );
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock.TestDirective);
+        stubDirective(cache, actualHostDirective.TestDirective, mockHostDirective.TestDirective);
+
+        @Component({
+            template: '<div test></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testDirective = root.debugElement.query(By.directive(mock.TestDirective));
+        const testHostDirective = root.debugElement.query(By.directive(mockHostDirective.TestDirective));
+
+        expect(testDirective.injector.get(mock.TestDirective)).toBeTruthy();
+        expect(testHostDirective.injector.get(mockHostDirective.TestDirective)).toBeTruthy();
+        expect(testDirective.nativeElement).toBe(testHostDirective.nativeElement);
+    });
+
+    it('stub directive with host directives that not imported', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-host-directives.directive')>(
+            './__fixtures__/test-with-host-directives.directive',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-host-directives.directive')>(
+            './__fixtures__/test-with-host-directives.directive',
+        );
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock.TestDirective);
+
+        @Component({
+            template: '<div test></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testDirective = root.debugElement.query(By.directive(mock.TestDirective));
+
+        expect(testDirective.injector.get(mock.TestDirective)).toBeTruthy();
+    });
+
+    it('stub directive with signal inputs', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-with-signal-inputs.directive')>(
+            './__fixtures__/test-with-signal-inputs.directive',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-with-signal-inputs.directive')>(
+            './__fixtures__/test-with-signal-inputs.directive',
+        );
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock.TestDirective);
+
+        @Component({
+            template: '<div test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('stub directive with host directives that have inputs', () => {
+        const actual = jest.requireActual<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.directive');
+        const mock = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.directive');
+        const actualHostDirective = jest.requireActual<
+            typeof import('./__fixtures__/test-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-signal-inputs.directive');
+        const mockHostDirective = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-signal-inputs.directive');
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock.TestDirective);
+        stubDirective(cache, actualHostDirective.TestDirective, mockHostDirective.TestDirective);
+
+        @Component({
+            template: '<div test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('stub directive with host directives that have inputs and not imported', () => {
+        const actual = jest.requireActual<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.directive');
+        const mock = jest.createMockFromModule<
+            typeof import('./__fixtures__/test-with-host-directives-with-signal-inputs.directive')
+        >('./__fixtures__/test-with-host-directives-with-signal-inputs.directive');
+
+        const cache = new StubCache();
+
+        stubDirective(cache, actual.TestDirective, mock.TestDirective);
+
+        @Component({
+            template: '<div test [value1]="`test`" [value2]="`test`" [aValue3]="`test`" [aValue4]="`test`"></div>',
+            imports: [mock.TestDirective],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+});

--- a/src/automocks/stub-directive.ts
+++ b/src/automocks/stub-directive.ts
@@ -1,0 +1,42 @@
+import { Type, ɵɵdefineDirective } from '@angular/core';
+
+import type { StubCache } from './stub-cache';
+import { stubHostDirectives } from './stub-host-directives';
+import { stubInputsFactory } from './stub-inputs-factory';
+import { DirectiveType } from './types';
+
+export function stubDirective<T>(cache: StubCache, actual: Type<T>, mock: Type<T>): asserts mock is DirectiveType<T> {
+    const { selectors, exportAs, standalone, signals, hostDirectives, inputs, inputConfig } = (
+        actual as DirectiveType<T>
+    ).ɵdir;
+
+    cache.setMock(actual, mock);
+
+    Object.defineProperty(mock, 'ɵdir', {
+        get: () =>
+            cache.getOrCreateDirectiveDef(actual, () => {
+                const features: never[] = [];
+
+                stubHostDirectives(cache, hostDirectives, features);
+
+                return ɵɵdefineDirective({
+                    type: mock,
+                    selectors,
+                    inputs: inputConfig,
+                    outputs: {},
+                    exportAs: exportAs ?? undefined,
+                    standalone,
+                    signals,
+                    features,
+                });
+            }),
+    });
+
+    let factory = () => new mock();
+
+    factory = stubInputsFactory(factory, inputs);
+
+    Object.defineProperty(mock, 'ɵfac', {
+        value: factory,
+    });
+}

--- a/src/automocks/stub-host-directives.ts
+++ b/src/automocks/stub-host-directives.ts
@@ -1,0 +1,35 @@
+import { Type, ɵComponentDef, ɵDirectiveDef, ɵɵHostDirectivesFeature } from '@angular/core';
+import { jest } from '@jest/globals';
+
+import { StubCache } from './stub-cache';
+import { stubDirective } from './stub-directive';
+
+export function stubHostDirectives<T>(
+    cache: StubCache,
+    hostDirectives: (ɵDirectiveDef<T> | ɵComponentDef<T>)['hostDirectives'],
+    features: unknown[],
+): void {
+    if (hostDirectives) {
+        features.push(
+            ɵɵHostDirectivesFeature(
+                hostDirectives.map((hostDirective) => {
+                    if (typeof hostDirective === 'object') {
+                        return {
+                            directive: cache.getMock(hostDirective.directive, () => {
+                                const mock = jest.fn(() => ({})) as unknown as Type<T>;
+
+                                stubDirective(new StubCache(), hostDirective.directive, mock);
+
+                                return mock;
+                            }),
+                            inputs: Object.entries(hostDirective.inputs).flat(),
+                            outputs: [],
+                        };
+                    } else {
+                        throw new Error('Unknown case');
+                    }
+                }),
+            ),
+        );
+    }
+}

--- a/src/automocks/stub-injectable.spec.ts
+++ b/src/automocks/stub-injectable.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StubCache } from './stub-cache';
+import { stubInjectable } from './stub-injectable';
+
+describe('stubInjectable', () => {
+    it('should stub root service', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/root.service')>('./__fixtures__/root.service');
+        const mock =
+            jest.createMockFromModule<typeof import('./__fixtures__/root.service')>('./__fixtures__/root.service');
+
+        const cache = new StubCache();
+
+        stubInjectable(cache, actual.RootService, mock.RootService);
+
+        const service = TestBed.inject(mock.RootService);
+
+        expect(jest.isMockFunction(service.method)).toBeTruthy();
+    });
+
+    it('should stub non root service', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/non-root.service')>(
+            './__fixtures__/non-root.service',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/non-root.service')>(
+            './__fixtures__/non-root.service',
+        );
+
+        const cache = new StubCache();
+
+        stubInjectable(cache, actual.NonRootService, mock.NonRootService);
+
+        expect(() => TestBed.inject(mock.NonRootService)).toThrow();
+
+        TestBed.resetTestingModule();
+
+        TestBed.configureTestingModule({
+            providers: [mock.NonRootService],
+        });
+
+        const service = TestBed.inject(mock.NonRootService);
+
+        expect(jest.isMockFunction(service.method)).toBeTruthy();
+    });
+});

--- a/src/automocks/stub-injectable.ts
+++ b/src/automocks/stub-injectable.ts
@@ -1,0 +1,23 @@
+import { Type, ɵɵdefineInjectable } from '@angular/core';
+
+import { StubCache } from './stub-cache';
+import { InjectableType } from './types';
+
+export function stubInjectable<T>(cache: StubCache, actual: Type<T>, mock: Type<T>): asserts mock is InjectableType<T> {
+    const { providedIn } = (actual as InjectableType<T>).ɵprov;
+
+    cache.setMock(actual, mock);
+
+    Object.defineProperty(mock, 'ɵprov', {
+        get: () =>
+            ɵɵdefineInjectable({
+                token: mock,
+                providedIn,
+                factory: () => new mock(),
+            }),
+    });
+
+    Object.defineProperty(mock, 'ɵfac', {
+        value: () => new mock(),
+    });
+}

--- a/src/automocks/stub-inputs-factory.ts
+++ b/src/automocks/stub-inputs-factory.ts
@@ -1,0 +1,27 @@
+import { input } from '@angular/core';
+
+import { InputFlags } from './types';
+
+export function stubInputsFactory<T>(
+    factory: () => T,
+    inputs: Record<string, [minifiedName: string, flags: InputFlags, transform: ((value: unknown) => unknown) | null]>,
+): () => T {
+    return () => {
+        const obj = factory();
+
+        for (const [propertyName, flags] of Object.values(inputs)) {
+            switch (flags) {
+                case InputFlags.SignalBased: {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (obj as any)[propertyName] = input();
+
+                    break;
+                }
+                default:
+                    throw new Error('Unknown input flag');
+            }
+        }
+
+        return obj;
+    };
+}

--- a/src/automocks/stub-module.spec.ts
+++ b/src/automocks/stub-module.spec.ts
@@ -1,0 +1,89 @@
+import { Component, Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { StubCache } from './stub-cache';
+import { stubComponent } from './stub-component';
+import { stubDirective } from './stub-directive';
+import { stubModule } from './stub-module';
+import { stubPipe } from './stub-pipe';
+
+describe('stubModule', () => {
+    it.each(['test-not-standalone', 'test'] as const)('stub simple module', (modulePath) => {
+        const actual = jest.requireActual<{ TestModule: Type<object> }>(`./__fixtures__/${modulePath}.module`);
+        const mock = jest.createMockFromModule<{ TestModule: Type<object> }>(`./__fixtures__/${modulePath}.module`);
+        const actualComponent = jest.requireActual<{ TestComponent: Type<object> }>(
+            `./__fixtures__/${modulePath}.component`,
+        );
+        const mockComponent = jest.createMockFromModule<{ TestComponent: Type<object> }>(
+            `./__fixtures__/${modulePath}.component`,
+        );
+        const actualDirective = jest.requireActual<{ TestDirective: Type<object> }>(
+            `./__fixtures__/${modulePath}.directive`,
+        );
+        const mockDirective = jest.createMockFromModule<{ TestDirective: Type<object> }>(
+            `./__fixtures__/${modulePath}.directive`,
+        );
+        const actualPipe = jest.requireActual<{ TestPipe: Type<object> }>(`./__fixtures__/${modulePath}.pipe`);
+        const mockPipe = jest.createMockFromModule<{ TestPipe: Type<object> }>(`./__fixtures__/${modulePath}.pipe`);
+
+        const cache = new StubCache();
+
+        stubModule(cache, actual.TestModule, mock.TestModule);
+        stubComponent(cache, actualComponent.TestComponent, mockComponent.TestComponent);
+        stubDirective(cache, actualDirective.TestDirective, mockDirective.TestDirective);
+        stubPipe(cache, actualPipe.TestPipe, mockPipe.TestPipe);
+
+        @Component({
+            template: `
+                <test></test>
+                <div test>{{ 'value' | test }}</div>
+            `,
+            imports: [mock.TestModule],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.mocked(mockPipe.TestPipe).prototype.transform.mockImplementation((value: string) => `test ${value}`);
+
+        const root = TestBed.createComponent(RootComponent);
+
+        root.detectChanges();
+
+        const testComponentElement = root.debugElement.query(By.directive(mockComponent.TestComponent));
+        const testDirectiveElement = root.debugElement.query(By.directive(mockDirective.TestDirective));
+
+        expect(testComponentElement).toBeTruthy();
+        expect(testDirectiveElement).toBeTruthy();
+        expect(testComponentElement.componentInstance).toBeInstanceOf(mockComponent.TestComponent);
+        expect(testDirectiveElement.nativeElement.innerHTML).toBe('test value');
+    });
+
+    it('stub simple module with component that not imported', () => {
+        const actual = jest.requireActual<typeof import('./__fixtures__/test-not-standalone.module')>(
+            './__fixtures__/test-not-standalone.module',
+        );
+        const mock = jest.createMockFromModule<typeof import('./__fixtures__/test-not-standalone.module')>(
+            './__fixtures__/test-not-standalone.module',
+        );
+
+        const cache = new StubCache();
+
+        stubModule(cache, actual.TestModule, mock.TestModule);
+
+        @Component({
+            template: '<test></test>',
+            imports: [mock.TestModule],
+            standalone: true,
+        })
+        class RootComponent {}
+
+        jest.spyOn(console, 'error');
+
+        expect(() => {
+            TestBed.createComponent(RootComponent).detectChanges();
+        }).not.toThrow();
+
+        expect(console.error).not.toHaveBeenCalled();
+    });
+});

--- a/src/automocks/stub-module.ts
+++ b/src/automocks/stub-module.ts
@@ -1,0 +1,50 @@
+import { Type, ɵNgModuleDef, ɵɵdefineNgModule } from '@angular/core';
+
+import { stubAnything } from './stub-anything';
+import type { StubCache } from './stub-cache';
+import { stubConstructor } from './stub-constructor';
+import { ModuleType } from './types';
+
+function assertNotFunction<T>(value: T): asserts value is Exclude<T, (...args: unknown[]) => unknown> {
+    if (typeof value === 'function') {
+        throw new Error('Not implemented');
+    }
+}
+
+function stubArray<T extends Type<unknown>>(cache: StubCache, actual: T[]): T[] {
+    return actual.map((itemActual) =>
+        cache.getMock(itemActual, () => stubConstructor(cache, itemActual, stubAnything)),
+    ) as T[];
+}
+
+export function stubModule<T>(cache: StubCache, actual: Type<T>, mock: Type<T>): asserts mock is ModuleType<T> {
+    const {
+        imports: importsActual,
+        exports: exportsActual,
+        declarations: declarationsActual,
+    } = (actual as ModuleType<T>).ɵmod;
+
+    assertNotFunction(importsActual);
+    assertNotFunction(exportsActual);
+    assertNotFunction(declarationsActual);
+
+    cache.setMock(actual, mock);
+
+    Object.defineProperty(mock, 'ɵmod', {
+        get: () =>
+            cache.getOrCreateModuleDef(
+                actual,
+                () =>
+                    ɵɵdefineNgModule({
+                        type: mock,
+                        imports: stubArray(cache, importsActual),
+                        declarations: stubArray(cache, declarationsActual),
+                        exports: stubArray(cache, exportsActual),
+                    }) as ɵNgModuleDef<T>,
+            ),
+    });
+
+    Object.defineProperty(mock, 'ɵfac', {
+        value: () => new mock(),
+    });
+}

--- a/src/automocks/stub-pipe.spec.ts
+++ b/src/automocks/stub-pipe.spec.ts
@@ -1,0 +1,35 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { StubCache } from './stub-cache';
+import { stubPipe } from './stub-pipe';
+
+it('stubPipe', () => {
+    const actual = jest.requireActual<typeof import('./__fixtures__/test.pipe')>('./__fixtures__/test.pipe');
+    const mock = jest.createMockFromModule<typeof import('./__fixtures__/test.pipe')>('./__fixtures__/test.pipe');
+
+    const cache = new StubCache();
+
+    stubPipe(cache, actual.TestPipe, mock.TestPipe);
+
+    @Component({
+        template: '{{value() | test}}',
+        imports: [mock.TestPipe],
+    })
+    class RootComponent {
+        public readonly value = signal('value');
+    }
+
+    const root = TestBed.createComponent(RootComponent);
+
+    root.detectChanges();
+
+    expect(root.debugElement.nativeElement.innerHTML).toBe('');
+
+    root.componentInstance.value.set('test');
+    jest.mocked(mock.TestPipe.prototype.transform).mockImplementation(() => 'stub value');
+
+    root.detectChanges();
+
+    expect(root.debugElement.nativeElement.innerHTML).toBe('stub value');
+});

--- a/src/automocks/stub-pipe.ts
+++ b/src/automocks/stub-pipe.ts
@@ -1,0 +1,28 @@
+import { Type, ɵPipeDef, ɵɵdefinePipe } from '@angular/core';
+
+import { StubCache } from './stub-cache';
+import { PipeType } from './types';
+
+export function stubPipe<T>(cache: StubCache, actual: Type<T>, mock: Type<T>): asserts mock is PipeType<T> {
+    const { name, pure, standalone } = (actual as PipeType<T>).ɵpipe;
+
+    cache.setMock(actual, mock);
+
+    Object.defineProperty(mock, 'ɵpipe', {
+        get: () =>
+            cache.getOrCreatePipeDef(
+                actual,
+                () =>
+                    ɵɵdefinePipe({
+                        name,
+                        type: mock,
+                        pure,
+                        standalone,
+                    }) as ɵPipeDef<T>,
+            ),
+    });
+
+    Object.defineProperty(mock, 'ɵfac', {
+        value: () => new mock(),
+    });
+}

--- a/src/automocks/types.ts
+++ b/src/automocks/types.ts
@@ -1,0 +1,32 @@
+import { Type, ɵComponentDef, ɵDirectiveDef, ɵNgModuleDef, ɵPipeDef, ɵɵInjectableDeclaration } from '@angular/core';
+
+export interface ComponentType<T> extends Type<T> {
+    ɵcmp: ɵComponentDef<T>;
+    ɵfac: () => T;
+}
+
+export interface DirectiveType<T> extends Type<T> {
+    ɵdir: ɵDirectiveDef<T>;
+    ɵfac: () => T;
+}
+
+export interface PipeType<T> extends Type<T> {
+    ɵpipe: ɵPipeDef<T>;
+    ɵfac: () => T;
+}
+
+export interface ModuleType<T> extends Type<T> {
+    ɵmod: ɵNgModuleDef<T>;
+    ɵfac: () => T;
+}
+
+export interface InjectableType<T> extends Type<T> {
+    ɵprov: ɵɵInjectableDeclaration<T>;
+    ɵfac: () => T;
+}
+
+export enum InputFlags {
+    None = 0,
+    SignalBased = 1,
+    HasDecoratorInputTransform = 2,
+}

--- a/website/docs/guides/automocks.md
+++ b/website/docs/guides/automocks.md
@@ -1,0 +1,287 @@
+---
+id: automatic-mocking
+title: Automatic Mocks
+---
+
+:::important
+**New in Jest Preset Angular v14.6+** – Automatic mocking for Angular components and classes (requires **Jest 30** or newer). This feature is **opt-in** and must be enabled in your Jest setup.
+:::
+
+## Why Automatic Mocks?
+
+When testing Angular applications, you often need to isolate a component or service under test from its Angular dependencies. In the past, this meant manually creating stub components, using `NO_ERRORS_SCHEMA`, `TestBed.override...` functions, third party services, or creating mock entities manually. With **automatic mocking**, `jest-preset-angular` can generate **stubbed Angular components, directives, pipes, modules, and services** on the fly whenever you use Jest’s module mocking. This helps to:
+
+- **Simplify Test Setup:** Avoid writing boilerplate stubs for every child component or injected service, avoid using third-party libraries. Instead, let Jest auto-mock entire Angular modules or libraries, and the preset will replace Angular classes with safe stubs.
+- **Prevent Injection Errors:** By default, Jest’s auto-mocks replace Angular factory functions (`ɵfac`) with `jest.fn()` returning `undefined`, causing injection to fail. The automatic mocking system fixes these by providing factories that return stub instances, so your components can inject services without errors.
+- **Isolate External Dependencies:** You can mock out an entire Angular library with a single `jest.mock('some-angular-lib')` call. The preset will stub all components/directives/pipes from that library, so your tests don’t execute their templates or logic, improving test performance and focus.
+
+## Enabling Automatic Mocks
+
+To activate this feature, you need to register it in your Jest configuration. The preset provides a function `setupAutoMocks()` which uses Jest’s `jest.onGenerateMock()` hook internally. You should call this **before your tests run**, typically in a Jest setup file. Here’s how to configure it:
+
+### Setup
+
+In your project root, update a setup file with following contents:
+
+```ts title="setup-jest.ts" tab={"label":"Setup file CJS"}
+import { setupAutoMocks } from 'jest-preset-angular/setup-env/automocks';
+
+setupAutoMocks();
+```
+
+```ts title="setup-jest.ts" tab={"label":"Setup file ESM"}
+import { setupAutoMocks } from 'jest-preset-angular/setup-env/automocks.mjs';
+
+setupAutoMocks();
+```
+
+Update `setupFilesAfterEnv` in your Jest config as following:
+
+```ts title="jest.config.ts"
+import type { Config } from 'jest';
+import { createCjsPreset } from 'jest-preset-angular/presets';
+
+export default {
+  ...createCjsPreset(),
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
+} satisfies Config;
+```
+
+## Using Automatic Mocks in Tests
+
+Once enabled, using the auto-mocking is straightforward. You trigger it by mocking the modules or components you want stubbed. This can be done via explicit `jest.mock` calls (or by setting `automock: true` in your Jest config, though explicit mocking is more common in Angular tests).
+
+Here are some usage examples:
+
+### Mocking Angular Service
+
+Suppose you have `SomeService` provided in `root` by an external library `external-lib`, and your component uses `inject(SomeService)`. In your test, do:
+
+```ts title="my.component.ts" tab={"label":"my.component.ts"}
+import { Component, inject } from '@angular/core';
+import { SomeService } from 'external-lib';
+
+@Component({
+  selector: 'my',
+  template: `<button (click)="onButtonClick()">Click me</button>`,
+})
+export class MyComponent {
+  private readonly someService = inject(SomeService);
+
+  public onButtonClick(): void {
+    this.someService.doSomething();
+  }
+}
+```
+
+```ts title="my.component.spec.ts" tab={"label":"my.component.spec.ts"}
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SomeService } from 'external-lib';
+
+import { MyComponent } from './my.component';
+
+jest.mock('external-lib');
+
+describe('MyComponent', () => {
+  let fixture: ComponentFixture<MyComponent>;
+  let someService: jest.Mocked<SomeService>;
+
+  beforeEach(() => {
+    someService = jest.mocked(TestBed.inject(SomeService));
+
+    fixture = TestBed.createComponent(MyComponent);
+    fixture.detectChanges();
+  });
+
+  describe('on button click', () => {
+    beforeEach(() => {
+      fixture.debugElement.query(By.css('button')).triggerEventHandler('click', null);
+    });
+
+    it('should call doSomething on SomeService', () => {
+      expect(someService.doSomething).toHaveBeenCalled();
+    });
+  });
+});
+```
+
+Now `SomeService` is replaced by a stub class. Its Angular factory (`ɵfac`) is adjusted to return a new instance of the stub, so `inject(SomeService)` will get a valid object (not `undefined`). Any methods on the service are Jest mocks (no-op by default), which you can spy on or configure as needed. For example, `SomeService.prototype.myMethod` will be a `jest.fn` that you can `.mockReturnValue(...)` in your test. Your component can call `someService.doSomething()` without error, and you can verify the call via `expect(someService.myMethod).toHaveBeenCalled()`.
+
+### Mocking Angular Component
+
+Suppose you have `SomeService` provided in `root` by an external library `external-lib`, and your component uses `inject(SomeService)`. In your test, do:
+
+```ts title="my.component.ts" tab={"label":"my.component.ts"}
+import { Component, input, signal } from '@angular/core';
+import { SomeComponent } from 'external-lib';
+
+@Component({
+  selector: 'my',
+  template: `
+    @if (isVisible()) {
+      <some [value]="value()" (helloWorld)="onHelloWorld($event)" />
+    }
+  `,
+  imports: [SomeComponent],
+})
+export class MyComponent {
+  public readonly isVisible = input(false);
+  public readonly value = signal('');
+
+  public onHelloWorld(data: string): void {
+    console.log(data);
+  }
+}
+```
+
+```ts title="my.component.spec.ts" tab={"label":"my.component.spec.ts"}
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SomeComponent } from 'external-lib';
+
+import { MyComponent } from './my.component';
+
+jest.mock('external-lib');
+
+describe('MyComponent', () => {
+  let fixture: ComponentFixture<MyComponent>;
+  let component: MyComponent;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('if isVisible is true', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('isVisible', true);
+      fixture.detectChanges();
+    });
+
+    it('should render SomeComponent', () => {
+      expect(fixture.debugElement.query(By.directive(SomeComponent))).toBeTruthy();
+    });
+
+    describe('on helloWorld event', () => {
+      beforeEach(() => {
+        jest.spyOn(component, 'onHelloWorld');
+
+        fixture.debugElement.query(By.directive(SomeComponent)).triggerEventHandler('helloWorld', 'hello');
+      });
+
+      it('should call onHelloWorld', () => {
+        expect(component.onHelloWorld).toHaveBeenCalledWith('hello');
+      });
+    });
+  });
+
+  describe('if isVisible is false', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('isVisible', false);
+      fixture.detectChanges();
+    });
+
+    it('should not render SomeComponent', () => {
+      expect(fixture.debugElement.query(By.directive(SomeComponent))).toBeFalsy();
+    });
+  });
+});
+```
+
+With `external-lib` mocked, `SomeComponent` is now a stub Component. These stub components have the same selector and input properties as the real ones, but their template is empty and their methods are no-ops. This means Angular’s rendering won’t error out – it recognizes the `<some>` element via the stub – but none of the real component’s logic runs. In your test, you can still interact with `MyComponent` and even set inputs on the stubbed child component if needed. The stub child’s outputs are omitted, so you can emit values by `debugElement.triggerEventHandler('event', data)`.
+
+### Mocking Angular Pipe
+
+Suppose you have `SomeService` provided in `root` by an external library `external-lib`, and your component uses `inject(SomeService)`. In your test, do:
+
+```ts title="my.component.ts" tab={"label":"my.component.ts"}
+import { Component, signal } from '@angular/core';
+import { SomePipe } from 'external-lib';
+
+@Component({
+  selector: 'my',
+  template: ` <p>{{ value() | some }}</p> `,
+  imports: [SomePipe],
+})
+export class MyComponent {
+  public readonly value = signal('');
+}
+```
+
+```ts title="my.component.spec.ts" tab={"label":"my.component.spec.ts"}
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SomePipe } from 'external-lib';
+
+import { MyComponent } from './my.component';
+
+jest.mock('external-lib');
+
+describe('MyComponent', () => {
+  let fixture: ComponentFixture<MyComponent>;
+  let component: MyComponent;
+
+  beforeEach(() => {
+    jest.mocked(SomePipe).prototype.transform.mockReturnValue('transformed');
+
+    fixture = TestBed.createComponent(MyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render transformed value', () => {
+    expect(fixture.nativeElement.textContent).toBe('transformed');
+  });
+
+  describe('if value changes', () => {
+    beforeEach(() => {
+      component.value.set('new value');
+      jest.mocked(SomePipe).prototype.transform.mockReturnValue('new transformed');
+      fixture.detectChanges();
+    });
+
+    it('should render new transformed value', () => {
+      expect(fixture.nativeElement.textContent).toBe('new transformed');
+    });
+  });
+});
+```
+
+Similarly, if your component template uses a pipe or directive from an external module, auto-mocking that module will stub those as well. A stub pipe implements a `transform()` method that by default returns `undefined` and is a `jest.fn` – so your component’s template can call the pipe without error. Stub directives are inert; they won’t run any real logic but will satisfy Angular’s compiler so that `[directive]` attributes or structural directives (e.g. `*externalDir`) don’t cause unknown selector errors.
+
+These examples demonstrate how you can quickly stub out entire dependencies. You no longer need to specify schemas or declare dummy components for every child – a single `jest.mock()` does the job. The stubbed pieces will seamlessly integrate, letting you focus on testing the logic of your component or service under test.
+
+## How Does It Work?
+
+Under the hood, the automatic mocking system relies on several utilities to create minimal Angular-compatible substitutes:
+
+- **[Jest automatic mock](https://jestjs.io/docs/es6-class-mocks#automatic-mock)** – Jest’s built-in `jest.mock()` function creates a mock module that can be used in your tests. It replaces all statically accessible methods and classes of original module by `jest.fn()`.
+
+- **[Jest onGenerateMock hook](https://jestjs.io/blog/2025/06/04/jest-30#jestongeneratemockcallback)** – Jest 30 introduced the `jest.onGenerateMock(callback)` API, which allows transforming automatically generated mocks. `setupAutoMocks()` registers a callback that is invoked whenever Jest auto-mocks a module. The callback receives the module’s mock exports and scans through them to find any Angular Ivy entities.
+
+In summary, when you mock a module using Jest, the preset’s hook transforms the resulting module object by replacing each export with either the original Jest mock (for non-Angular entities) or a rich stub (for Angular entities). The outcome is that your test sees a module where Angular classes are present (so Angular can consume them) but they are all dummy implementations. This all happens behind the scenes when the module is first imported in the test.
+
+## Notes and Limitations
+
+Keep the following in mind when using the automatic mocking:
+
+- **Jest Version Requirement:** This feature only works with **Jest v30 or later**, since it uses the `jest.onGenerateMock` API introduced in Jest 30. Ensure you’ve upgraded Jest. If the hook is not supported, calling `setupAutoMocks()` will throw an error or have no effect.
+
+- **Opt-In Behavior:** Automatic mocking is _not_ enabled by default to avoid surprising behaviors in existing tests. You must call `setupAutoMocks()` (typically in your `setupFilesAfterEnv`). If you decide not to use it, Jest will continue to auto-mock modules in the normal way (and Angular internals might remain problematic without manual intervention).
+
+- **Only Affects Auto-Mocks:** The `onGenerateMock` hook only runs for **automatically generated mocks** – that is, when you use `jest.mock('moduleName')` with no manual factory, or if you have `automock: true` for all modules. It **does not** run for modules you manually mock with a factory or those with a custom `__mocks__` implementation. In those cases, you are responsible for providing any needed stubs. (You can still manually use the stub utilities if desired, but that’s an advanced use case.)
+
+- **Combining with Manual Spies:** The stubbed classes and instances are still Jest mocks under the hood. You can treat them like any mock – for example, use `.mockReturnValue` or `.mockImplementation` on stubbed methods to tailor their behavior. A stubbed pipe’s `transform` can be overridden to return specific values if your component logic depends on it. The automatic stub provides the structure, and you are free to customize the behavior in your test.
+
+- **No Real Logic Executed:** By design, **none** of the original component/directive/pipe logic runs. If your test inadvertently relies on some effect of an external component (e.g. a child component’s lifecycle setting up something, or a pipe computing a value), be aware that with the dependency stubbed, that effect won’t happen. Usually this is what you want in unit tests. If you do need the real behavior, you should not mock that particular module or component.
+
+- **Maintaining API:** The stub generation attempts to preserve the public API of components/directives so that binding to them in templates won’t throw errors. However, the **values** of those inputs are not used by any internal logic (since there is none). If a child stub component has an input that your component sets, it will accept the value, but it doesn’t do anything with it. Similarly, outputs won’t emit on their own. You can manually trigger an output if needed for your test scenario (via `debugElement.triggerEventHandler` method).
+
+- **Module Imports and Providers:** When stubbing an NgModule, the system will recursively stub its declarations (and possibly imported modules).
+
+- **Interaction with Other Mocking Libraries:** If you are using libraries like `ng-mocks` or others that provide their own Angular stubs, be cautious. The automatic Ivy mocks from `jest-preset-angular` may overlap in purpose. It’s recommended to use one approach consistently. If you enable `setupAutoMocks()`, you typically do not need to call `MockComponent`/`MockService` from other libraries for the same dependencies, as the preset will have already replaced them.
+
+- **Troubleshooting:** If a mock isn’t behaving as expected, you can inspect the stub. For example, logging `fixture.debugElement.query(By.directive(SomeChildComponent)).componentInstance.method`. If it is an instance of `jest.Mock`, this can help confirm that the auto-mocking occurred. We welcome issues or PRs if you find something that the automatic stubbing doesn’t cover.
+
+By leveraging automatic Ivy mocks, you can significantly streamline your Angular unit tests. Instead of spending time writing dummy implementations of components or worrying about Angular internals in your mocks, you let `jest-preset-angular` handle the heavy lifting. Focus on your test assertions, and enjoy fewer setup headaches when dealing with Angular entities!

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -3,7 +3,6 @@ import { translate } from '@docusaurus/Translate';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-// eslint-disable-next-line import/no-named-as-default
 import clsx from 'clsx';
 import React from 'react';
 


### PR DESCRIPTION
## Summary

Currently, to mock Angular components, services, pipes, directives, and modules, we need to manually create stubs for them. This PR introduces a new way to automatically mock them. The process can be simplified as follows:

```
jest.mock('./component');
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## TODO

- [x] Add mock transformer implementation
- [x] Add unit tests
- [x] Add e2e tests
- [x] Add documentation
- [x] Expose `setupAutoMocks` function 
- [x] Wait for the release of jest@30.
- [x] Blocked by https://github.com/jestjs/jest/pull/15482
- [x] Wait for merge #3175
- [x] Test outputs
- [x] Test manually created mocks (`__mocks__`)

---

Closes: #2908
