### PR TITLE
refactor: drop support for Angular 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,22 +49,22 @@
   },
   "dependencies": {
     "bs-logger": "^0.2.6",
-    "esbuild-wasm": ">=0.20.1",
+    "esbuild-wasm": ">=0.23.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-util": "^29.7.0",
     "pretty-format": "^29.7.0",
     "ts-jest": "^29.3.0"
   },
   "optionalDependencies": {
-    "esbuild": ">=0.20.1"
+    "esbuild": ">=0.23.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": ">=17.0.0 <21.0.0",
-    "@angular/core": ">=17.0.0 <21.0.0",
-    "@angular/platform-browser-dynamic": ">=17.0.0 <21.0.0",
+    "@angular/compiler-cli": ">=18.0.0 <21.0.0",
+    "@angular/core": ">=18.0.0 <21.0.0",
+    "@angular/platform-browser-dynamic": ">=18.0.0 <21.0.0",
     "jest": "^29.0.0",
     "jsdom": ">=22.0.0",
-    "typescript": ">=5.4"
+    "typescript": ">=5.5"
   },
   "peerDependenciesMeta": {
     "jsdom": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6593,7 +6593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-wasm@npm:0.25.5, esbuild-wasm@npm:>=0.20.1":
+"esbuild-wasm@npm:0.25.5, esbuild-wasm@npm:>=0.23.0":
   version: 0.25.5
   resolution: "esbuild-wasm@npm:0.25.5"
   bin:
@@ -6602,7 +6602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.25.5, esbuild@npm:>=0.20.1, esbuild@npm:^0.25.0":
+"esbuild@npm:0.25.5, esbuild@npm:>=0.23.0, esbuild@npm:^0.25.0":
   version: 0.25.5
   resolution: "esbuild@npm:0.25.5"
   dependencies:
@@ -8940,8 +8940,8 @@ __metadata:
     chalk: "npm:^4.1.2"
     conventional-changelog-cli: "npm:^5.0.0"
     cross-env: "npm:^7.0.3"
-    esbuild: "npm:>=0.20.1"
-    esbuild-wasm: "npm:>=0.20.1"
+    esbuild: "npm:>=0.23.0"
+    esbuild-wasm: "npm:>=0.23.0"
     eslint: "npm:^9.28.0"
     eslint-config-prettier: "npm:^10.1.2"
     eslint-plugin-import: "npm:^2.31.0"
@@ -8971,12 +8971,12 @@ __metadata:
     typescript-eslint: "npm:^8.31.0"
     zone.js: "npm:~0.15.1"
   peerDependencies:
-    "@angular/compiler-cli": ">=17.0.0 <21.0.0"
-    "@angular/core": ">=17.0.0 <21.0.0"
-    "@angular/platform-browser-dynamic": ">=17.0.0 <21.0.0"
+    "@angular/compiler-cli": ">=18.0.0 <21.0.0"
+    "@angular/core": ">=18.0.0 <21.0.0"
+    "@angular/platform-browser-dynamic": ">=18.0.0 <21.0.0"
     jest: ^29.0.0
     jsdom: ">=22.0.0"
-    typescript: ">=5.4"
+    typescript: ">=5.5"
   dependenciesMeta:
     esbuild:
       optional: true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- The minimum supported version for Angular is **18** following Angular support policy https://angular.dev/reference/releases#actively-supported-versions

- The minimum supported version for TypeScript is **5.5** following Angular 18

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**