### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   verify_release:
     name: Verify release 🔍
+    permissions:
+      contents: read
     if: startsWith(github.event.head_commit.message, 'chore(release)')
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/thymikee/jest-preset-angular/security/code-scanning/8](https://github.com/thymikee/jest-preset-angular/security/code-scanning/8)

To fix the problem, add a `permissions` block to the `verify_release` job in `.github/workflows/release.yml` and set it to the minimum required permissions. Since the job only needs to read repository contents, set `permissions: contents: read`. This should be added directly under the job name (after line 11), before any other job configuration keys. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
