### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/actions/setup-docspace/action.yml
+++ b/.github/actions/setup-docspace/action.yml
@@ -16,6 +16,16 @@ runs:
         cache-dependency-path: 'website/yarn.lock'
         node-version: 22
 
+    - name: Restore cached node modules ♻️
+      id: cache-yarn
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: |
+          website/.yarn/cache
+          website/node_modules
+        key: node-22-website-build-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: node-22-website-build
+
     - name: Install dependencies 🔧
       run: yarn install --frozen-lockfile
       shell: bash

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,6 @@ jobs:
       # only required for workflows in private repositories
       actions: read
       contents: read
-
     strategy:
       fail-fast: false
       matrix:
@@ -46,4 +45,4 @@ jobs:
       - name: Perform CodeQL Analysis 🔍
         uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3
         with:
-          category: '/language:${{matrix.language}}'
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/pr-docs-check.yml
+++ b/.github/workflows/pr-docs-check.yml
@@ -15,6 +15,10 @@ concurrency:
   group: preview-doc-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: write # Required to push commits
+  pull-requests: write # If creating/updating PRs
+
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/thymikee/jest-preset-angular/security/code-scanning/7](https://github.com/thymikee/jest-preset-angular/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow. This can be done either at the root level (to apply to all jobs) or at the job level (to apply to a specific job). Since there is only one job (`deploy-preview`), adding it at the root is simplest and most maintainable. The minimal starting point is `contents: read`, but if the workflow needs to comment on pull requests or update their status, you may also need `pull-requests: write`. Based on the steps shown, the workflow likely only needs to read repository contents, so start with `contents: read`. If you later find that additional permissions are required (e.g., for commenting on PRs), you can add them.

Add the following block after the `name:` line and before the `on:` block in `.github/workflows/pr-docs-check.yml`:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
