### PR TITLE
fix: remove peer dep `jest-environment-jsdom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@angular/platform-browser": ">=18.0.0 <21.0.0",
     "@angular/platform-browser-dynamic": ">=18.0.0 <21.0.0",
     "jest": "^30.0.0",
-    "jest-environment-jsdom": "^30.0.0",
     "jsdom": ">=26.0.0",
     "typescript": ">=5.5"
   },

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 You can install `jest-preset-angular` and dependencies all at once with one of the following commands.
 
 ```bash npm2yarn
-npm install -D jest jest-preset-angular @types/jest
+npm install -D jest jest-preset-angular @types/jest jest-environment-jsdom jsdom
 ```
 
 ### Configuration

--- a/website/versioned_docs/version-14.x/getting-started/installation.md
+++ b/website/versioned_docs/version-14.x/getting-started/installation.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 You can install `jest-preset-angular` and dependencies all at once with one of the following commands.
 
 ```bash npm2yarn
-npm install -D jest jest-preset-angular @types/jest
+npm install -D jest jest-preset-angular @types/jest jest-environment-jsdom jsdom
 ```
 
 ### Configuration

--- a/website/versioned_docs/version-15.0/getting-started/installation.md
+++ b/website/versioned_docs/version-15.0/getting-started/installation.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 You can install `jest-preset-angular` and dependencies all at once with one of the following commands.
 
 ```bash npm2yarn
-npm install -D jest jest-preset-angular @types/jest
+npm install -D jest jest-preset-angular @types/jest jest-environment-jsdom jsdom
 ```
 
 ### Configuration

--- a/yarn.lock
+++ b/yarn.lock
@@ -8942,7 +8942,6 @@ __metadata:
     "@angular/platform-browser": ">=18.0.0 <21.0.0"
     "@angular/platform-browser-dynamic": ">=18.0.0 <21.0.0"
     jest: ^30.0.0
-    jest-environment-jsdom: ^30.0.0
     jsdom: ">=26.0.0"
     typescript: ">=5.5"
   dependenciesMeta:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Since Jest has validation for `jsdom` environment when `jest-environment-jsdom` doesn't exist, we can safely remove it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Closes #3331 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
