### PR TITLE
fix: handle `processWithEsbuild` transform option

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,5 @@
+import type { TsJestTransformerOptions } from 'ts-jest';
+
+export type NgJestTransformerOptions = TsJestTransformerOptions & {
+    processWithEsbuild?: string[];
+};

--- a/src/config/ng-jest-config.ts
+++ b/src/config/ng-jest-config.ts
@@ -14,6 +14,11 @@ export class NgJestConfig extends ConfigSet {
     constructor(jestConfig: TsJestTransformOptions['config'] | undefined, parentLogger?: Logger | undefined) {
         super(jestConfig, parentLogger);
         const jestGlobalsConfig = jestConfig?.globals?.ngJest ?? Object.create(null);
+        if (jestGlobalsConfig.processWithEsbuild) {
+            this.logger.warn(
+                'Specifying `processWithEsbuild` in `ngJest` config is deprecated and will be removed in the next major version. Please follow this documentation https://thymikee.github.io/jest-preset-angular/docs/getting-started/options#processing-with-esbuild instead.',
+            );
+        }
         this.processWithEsbuild = globsToMatcher([
             ...(jestGlobalsConfig.processWithEsbuild ?? []),
             ...defaultProcessWithEsbuildPatterns,

--- a/src/ng-jest-transformer.spec.ts
+++ b/src/ng-jest-transformer.spec.ts
@@ -98,6 +98,32 @@ describe('NgJestTransformer', () => {
         expect(mockedTransformSync).not.toHaveBeenCalled();
     });
 
+    test('should use esbuild to process files defined via "processWithEsbuild" transform option', () => {
+        const tr = new NgJestTransformer({
+            processWithEsbuild: ['foo.js'],
+        });
+        tr.process(
+            `
+      const pi = parseFloat(3.124);
+
+      export { pi };
+    `,
+            'foo.js',
+            {
+                config: {
+                    cwd: process.cwd(),
+                    extensionsToTreatAsEsm: [],
+                    testMatch: [],
+                    testRegex: [],
+                },
+            } as any, // eslint-disable-line @typescript-eslint/no-explicit-any,
+        );
+
+        expect(mockedTransformSync).toHaveBeenCalled();
+
+        mockedTransformSync.mockClear();
+    });
+
     test.each([
         {
             sourceMap: false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When we migrate from `globals` to transform option, the object `ngJest` wasn't copied by `ts-jest` parent class `ConfigSet`.

This fix adds the handling option `processWithEsbuild` directly to `NgJestTransformer` class to manage it properly and add a deprecation warning to `globals.ngJest.processWithEsbuild` option

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Green CI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
**N.A.**