### PR TITLE
fix: use named exports in setup-env .d.ts files

### DIFF
--- a/setup-env/zone/index.d.ts
+++ b/setup-env/zone/index.d.ts
@@ -5,7 +5,4 @@ export interface SetupOptions extends TestEnvironmentOptions {
     extraProviders?: StaticProvider[];
 }
 
-declare const _default: {
-    setupZoneTestEnv: (options?: SetupOptions) => void;
-};
-export = _default;
+export declare const setupZoneTestEnv: (options?: SetupOptions) => void;

--- a/setup-env/zoneless/index.d.ts
+++ b/setup-env/zoneless/index.d.ts
@@ -5,7 +5,4 @@ export interface SetupOptions extends TestEnvironmentOptions {
     extraProviders?: StaticProvider[];
 }
 
-declare const _default: {
-    setupZonelessTestEnv: (options?: SetupOptions) => void;
-};
-export = _default;
+export declare const setupZonelessTestEnv: (options?: SetupOptions) => void;


### PR DESCRIPTION
## Summary

The `.d.ts` files in both `zone` and `zoneless` incorrectly mix `export interface` with `export = _default`. This causes a "TS2309: An export assignment cannot be used in a module with other exported elements" error when importing from these modules in TypeScript.

Remove `export = _default` and use named exports throughout. This matches the approach used in the respective `.d.mts` files.

## Test plan

I've tested this patch in a project using jest-preset-angular that encountered the TS2309 error. There is no type checking step in jest-preset-angular for the `setup-env` directory.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This bug has been present since jest-preset-angular v16.1.0.