### PR TITLE
build(deps): update yarn lockfile to stop failing CI

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12991,16 +12991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.4, semver@npm:^7.8.0, semver@npm:^7.8.2":
-  version: 7.8.2
-  resolution: "semver@npm:7.8.2"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/52221d8f1cadacda3cc3f0a2e7f7146e0442c7f4219acb25970bed055f5d0a6afbba5f22e293b078c2e93fca3dce0a08b088485e8b75d32a165f16c3627091c8
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.3":
+"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:^7.8.0, semver@npm:^7.8.2":
   version: 7.8.2
   resolution: "semver@npm:7.8.2"
   bin:


### PR DESCRIPTION
## Summary

Solves failing CI on the main branch caused by lockfile being out of sync
https://github.com/thymikee/jest-preset-angular/actions/runs/27153005953/job/80148592575
Note on #3811 these tests passed

## Test plan

All tests should pass now

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No