### PR TITLE
refactor: drop support for @angular/platform-browser-dynamic [#3497]

### DIFF
--- a/examples/example-app-monorepo/package.json
+++ b/examples/example-app-monorepo/package.json
@@ -21,7 +21,6 @@
     "@angular/core": "^21.0.7",
     "@angular/forms": "^21.0.2",
     "@angular/platform-browser": "^21.0.2",
-    "@angular/platform-browser-dynamic": "^21.0.2",
     "@angular/router": "^21.0.2",
     "angular-in-memory-web-api": "^0.21.0",
     "rxjs": "^7.8.2",

--- a/examples/example-app-monorepo/yarn.lock
+++ b/examples/example-app-monorepo/yarn.lock
@@ -537,20 +537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/platform-browser-dynamic@npm:^21.0.2":
-  version: 21.2.17
-  resolution: "@angular/platform-browser-dynamic@npm:21.2.17"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/common": 21.2.17
-    "@angular/compiler": 21.2.17
-    "@angular/core": 21.2.17
-    "@angular/platform-browser": 21.2.17
-  checksum: 10/337eb2986bd580f9763129c8416988230f21262e3b755066ab429a873d4144c6935878f017b46b8705dd1ae22907bbf8f07de8f52632848b45da260c58c94f95
-  languageName: node
-  linkType: hard
-
 "@angular/platform-browser@npm:^21.0.2":
   version: 21.2.17
   resolution: "@angular/platform-browser@npm:21.2.17"
@@ -6663,7 +6649,6 @@ __metadata:
     "@angular/core": "npm:^21.0.7"
     "@angular/forms": "npm:^21.0.2"
     "@angular/platform-browser": "npm:^21.0.2"
-    "@angular/platform-browser-dynamic": "npm:^21.0.2"
     "@angular/router": "npm:^21.0.2"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.13.2"

--- a/examples/example-app-v20/package.json
+++ b/examples/example-app-v20/package.json
@@ -16,7 +16,6 @@
     "@angular/core": "^20.3.16",
     "@angular/forms": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
-    "@angular/platform-browser-dynamic": "^20.0.0",
     "@angular/router": "^20.0.0",
     "angular-in-memory-web-api": "^0.20.0",
     "rxjs": "~7.8.2",

--- a/examples/example-app-v20/yarn.lock
+++ b/examples/example-app-v20/yarn.lock
@@ -397,20 +397,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/platform-browser-dynamic@npm:^20.0.0":
-  version: 20.3.25
-  resolution: "@angular/platform-browser-dynamic@npm:20.3.25"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/common": 20.3.25
-    "@angular/compiler": 20.3.25
-    "@angular/core": 20.3.25
-    "@angular/platform-browser": 20.3.25
-  checksum: 10/575db60910f6b2aa5c66ca8eb2911e10d95220465e7278d27fd1432e839f0eb68db9997a1fc27afe7f2660f5dac68a1981ab09052c7fd0770343bfecdb71f085
-  languageName: node
-  linkType: hard
-
 "@angular/platform-browser@npm:^20.0.0":
   version: 20.3.25
   resolution: "@angular/platform-browser@npm:20.3.25"
@@ -4358,7 +4344,6 @@ __metadata:
     "@angular/core": "npm:^20.3.16"
     "@angular/forms": "npm:^20.0.0"
     "@angular/platform-browser": "npm:^20.0.0"
-    "@angular/platform-browser-dynamic": "npm:^20.0.0"
     "@angular/router": "npm:^20.0.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.13.2"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@angular/compiler-cli": ">=20.0.0 <23.0.0",
     "@angular/core": ">=20.0.0 <23.0.0",
     "@angular/platform-browser": ">=20.0.0 <23.0.0",
-    "@angular/platform-browser-dynamic": ">=20.0.0 <23.0.0",
     "jest": "^30.0.0",
     "jsdom": ">=26.0.0",
     "typescript": ">=5.8"
@@ -78,7 +77,6 @@
     "@angular/forms": "^22.0.1",
     "@angular/material": "^22.0.1",
     "@angular/platform-browser": "^22.0.1",
-    "@angular/platform-browser-dynamic": "^22.0.1",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "@commitlint/cli": "^21.0.2",

--- a/setup-env/zone/index.js
+++ b/setup-env/zone/index.js
@@ -1,13 +1,9 @@
 require('zone.js');
 require('zone.js/testing');
 
-const { COMPILER_OPTIONS, NgModule, provideZoneChangeDetection, VERSION } = require('@angular/core');
+const { COMPILER_OPTIONS, NgModule, provideZoneChangeDetection } = require('@angular/core');
 const { getTestBed } = require('@angular/core/testing');
 const { BrowserTestingModule, platformBrowserTesting } = require('@angular/platform-browser/testing');
-const {
-    BrowserDynamicTestingModule,
-    platformBrowserDynamicTesting,
-} = require('@angular/platform-browser-dynamic/testing');
 
 const { polyfillEncoder, resolveTestEnvOptions } = require('../utils');
 
@@ -15,44 +11,24 @@ const setupZoneTestEnv = (options) => {
     polyfillEncoder();
     const resolvedOptions = resolveTestEnvOptions(options) ?? {};
     const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
-    if (+VERSION.major >= 21) {
-        class TestModule {}
-        NgModule({
-            providers: [provideZoneChangeDetection()],
-        })(TestModule);
 
-        getTestBed().initTestEnvironment(
-            [BrowserTestingModule, TestModule],
-            platformBrowserTesting([
-                {
-                    provide: COMPILER_OPTIONS,
-                    useValue: {},
-                    multi: true,
-                },
-                ...extraProviders,
-            ]),
-            testEnvironmentOptions,
-        );
-    } else if (+VERSION.major === 20) {
-        getTestBed().initTestEnvironment(
-            [BrowserTestingModule],
-            platformBrowserTesting([
-                {
-                    provide: COMPILER_OPTIONS,
-                    useValue: {},
-                    multi: true,
-                },
-                ...extraProviders,
-            ]),
-            testEnvironmentOptions,
-        );
-    } else {
-        getTestBed().initTestEnvironment(
-            [BrowserDynamicTestingModule],
-            platformBrowserDynamicTesting(extraProviders),
-            testEnvironmentOptions,
-        );
-    }
+    class TestModule {}
+    NgModule({
+        providers: [provideZoneChangeDetection()],
+    })(TestModule);
+
+    getTestBed().initTestEnvironment(
+        [BrowserTestingModule, TestModule],
+        platformBrowserTesting([
+            {
+                provide: COMPILER_OPTIONS,
+                useValue: {},
+                multi: true,
+            },
+            ...extraProviders,
+        ]),
+        testEnvironmentOptions,
+    );
 };
 
 module.exports = {

--- a/setup-env/zone/index.mjs
+++ b/setup-env/zone/index.mjs
@@ -1,10 +1,9 @@
 import 'zone.js';
 import 'zone.js/testing';
 
-import { COMPILER_OPTIONS, NgModule, provideZoneChangeDetection, VERSION } from '@angular/core';
+import { COMPILER_OPTIONS, NgModule, provideZoneChangeDetection } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
 import { polyfillEncoder, resolveTestEnvOptions } from '../utils';
 
@@ -12,44 +11,24 @@ const setupZoneTestEnv = (options) => {
     polyfillEncoder();
     const resolvedOptions = resolveTestEnvOptions(options) ?? {};
     const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
-    if (+VERSION.major >= 21) {
-        class TestModule {}
-        NgModule({
-            providers: [provideZoneChangeDetection()],
-        })(TestModule);
 
-        getTestBed().initTestEnvironment(
-            [BrowserTestingModule, TestModule],
-            platformBrowserTesting([
-                {
-                    provide: COMPILER_OPTIONS,
-                    useValue: {},
-                    multi: true,
-                },
-                ...extraProviders,
-            ]),
-            testEnvironmentOptions,
-        );
-    } else if (+VERSION.major === 20) {
-        getTestBed().initTestEnvironment(
-            [BrowserTestingModule],
-            platformBrowserTesting([
-                {
-                    provide: COMPILER_OPTIONS,
-                    useValue: {},
-                    multi: true,
-                },
-                ...extraProviders,
-            ]),
-            testEnvironmentOptions,
-        );
-    } else {
-        getTestBed().initTestEnvironment(
-            [BrowserDynamicTestingModule],
-            platformBrowserDynamicTesting(extraProviders),
-            testEnvironmentOptions,
-        );
-    }
+    class TestModule {}
+    NgModule({
+        providers: [provideZoneChangeDetection()],
+    })(TestModule);
+
+    getTestBed().initTestEnvironment(
+        [BrowserTestingModule, TestModule],
+        platformBrowserTesting([
+            {
+                provide: COMPILER_OPTIONS,
+                useValue: {},
+                multi: true,
+            },
+            ...extraProviders,
+        ]),
+        testEnvironmentOptions,
+    );
 };
 
 export { setupZoneTestEnv };

--- a/setup-env/zoneless/index.js
+++ b/setup-env/zoneless/index.js
@@ -2,10 +2,6 @@ const angularCore = require('@angular/core');
 const { ErrorHandler, NgModule, VERSION, COMPILER_OPTIONS } = require('@angular/core');
 const { getTestBed } = require('@angular/core/testing');
 const { BrowserTestingModule, platformBrowserTesting } = require('@angular/platform-browser/testing');
-const {
-    platformBrowserDynamicTesting,
-    BrowserDynamicTestingModule,
-} = require('@angular/platform-browser-dynamic/testing');
 
 const { polyfillEncoder, resolveTestEnvOptions } = require('../utils');
 const provideZonelessChangeDetectionFn =
@@ -37,26 +33,18 @@ const setupZonelessTestEnv = (options) => {
         polyfillEncoder();
         const resolvedOptions = resolveTestEnvOptions(options) ?? {};
         const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
-        if (+VERSION.major >= 20) {
-            getTestBed().initTestEnvironment(
-                [BrowserTestingModule, provideZonelessConfig()],
-                platformBrowserTesting([
-                    {
-                        provide: COMPILER_OPTIONS,
-                        useValue: {},
-                        multi: true,
-                    },
-                    ...extraProviders,
-                ]),
-                testEnvironmentOptions,
-            );
-        } else {
-            getTestBed().initTestEnvironment(
-                [BrowserDynamicTestingModule, provideZonelessConfig()],
-                platformBrowserDynamicTesting(extraProviders),
-                testEnvironmentOptions,
-            );
-        }
+        getTestBed().initTestEnvironment(
+            [BrowserTestingModule, provideZonelessConfig()],
+            platformBrowserTesting([
+                {
+                    provide: COMPILER_OPTIONS,
+                    useValue: {},
+                    multi: true,
+                },
+                ...extraProviders,
+            ]),
+            testEnvironmentOptions,
+        );
 
         return;
     }

--- a/setup-env/zoneless/index.mjs
+++ b/setup-env/zoneless/index.mjs
@@ -2,7 +2,6 @@ import * as angularCore from '@angular/core';
 import { ErrorHandler, NgModule, VERSION, COMPILER_OPTIONS } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
-import { platformBrowserDynamicTesting, BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 import { polyfillEncoder, resolveTestEnvOptions } from '../utils';
 
@@ -36,26 +35,18 @@ const setupZonelessTestEnv = (options) => {
         polyfillEncoder();
         const resolvedOptions = resolveTestEnvOptions(options) ?? {};
         const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
-        if (+VERSION.major >= 20) {
-            getTestBed().initTestEnvironment(
-                [BrowserTestingModule, provideZonelessConfig()],
-                platformBrowserTesting([
-                    {
-                        provide: COMPILER_OPTIONS,
-                        useValue: {},
-                        multi: true,
-                    },
-                    ...extraProviders,
-                ]),
-                testEnvironmentOptions,
-            );
-        } else {
-            getTestBed().initTestEnvironment(
-                [BrowserDynamicTestingModule, provideZonelessConfig()],
-                platformBrowserDynamicTesting(extraProviders),
-                testEnvironmentOptions,
-            );
-        }
+        getTestBed().initTestEnvironment(
+            [BrowserTestingModule, provideZonelessConfig()],
+            platformBrowserTesting([
+                {
+                    provide: COMPILER_OPTIONS,
+                    useValue: {},
+                    multi: true,
+                },
+                ...extraProviders,
+            ]),
+            testEnvironmentOptions,
+        );
 
         return;
     }

--- a/src/config/setup-env.spec.ts
+++ b/src/config/setup-env.spec.ts
@@ -27,28 +27,22 @@ jest.mock('@angular/core/testing', () => {
 });
 
 class BrowserTestingModuleStub {}
-class BrowserDynamicTestingModuleStub {}
 class PlatformRefStub {}
 class ErrorHandlerStub {}
 const mockPlatformBrowserTesting = jest.fn(() => new PlatformRefStub());
-const mockPlatformBrowserDynamicTesting = jest.fn(() => new PlatformRefStub());
 jest.mock('@angular/platform-browser/testing', () => {
     return {
         BrowserTestingModule: new BrowserTestingModuleStub(),
         platformBrowserTesting: mockPlatformBrowserTesting,
     };
 });
-jest.mock('@angular/platform-browser-dynamic/testing', () => {
-    return {
-        BrowserDynamicTestingModule: new BrowserDynamicTestingModuleStub(),
-        platformBrowserDynamicTesting: mockPlatformBrowserDynamicTesting,
-    };
-});
 const mockProvideExperimentalZonelessChangeDetection = jest.fn();
+const mockProvideZoneChangeDetection = jest.fn();
 const mockCompilerOptions = 'COMPILER_OPTIONS';
 jest.mock('@angular/core', () => {
     return {
         provideExperimentalZonelessChangeDetection: mockProvideExperimentalZonelessChangeDetection,
+        provideZoneChangeDetection: mockProvideZoneChangeDetection,
         ErrorHandler: ErrorHandlerStub,
         NgModule: () => {
             return jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,20 +491,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/platform-browser-dynamic@npm:^22.0.1":
-  version: 22.0.1
-  resolution: "@angular/platform-browser-dynamic@npm:22.0.1"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/common": 22.0.1
-    "@angular/compiler": 22.0.1
-    "@angular/core": 22.0.1
-    "@angular/platform-browser": 22.0.1
-  checksum: 10/cb6ce7d6976d56901b5e252dd6e17cf41aa2baf33465e7c94e7713da84af5fee3b3dd5535c0693a452a4c9dbf10c718098166034900d50aace29a0ba266ce385
-  languageName: node
-  linkType: hard
-
 "@angular/platform-browser@npm:^22.0.1":
   version: 22.0.1
   resolution: "@angular/platform-browser@npm:22.0.1"
@@ -9827,7 +9813,6 @@ __metadata:
     "@angular/forms": "npm:^22.0.1"
     "@angular/material": "npm:^22.0.1"
     "@angular/platform-browser": "npm:^22.0.1"
-    "@angular/platform-browser-dynamic": "npm:^22.0.1"
     "@babel/core": "npm:^7.29.7"
     "@babel/preset-env": "npm:^7.29.7"
     "@commitlint/cli": "npm:^21.0.2"
@@ -9885,7 +9870,6 @@ __metadata:
     "@angular/compiler-cli": ">=20.0.0 <23.0.0"
     "@angular/core": ">=20.0.0 <23.0.0"
     "@angular/platform-browser": ">=20.0.0 <23.0.0"
-    "@angular/platform-browser-dynamic": ">=20.0.0 <23.0.0"
     jest: ^30.0.0
     jsdom: ">=26.0.0"
     typescript: ">=5.8"


### PR DESCRIPTION
## Summary

Drop support for `@angular/platform-browser-dynamic`

## Test plan

`yarn test` (79/79) and `yarn lint` pass.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Other information

(AI-assisted)