### PR TITLE
refactor: remove `provideExperimentalZonelessChangeDetection` fallback

### DIFF
--- a/setup-env/zoneless/index.js
+++ b/setup-env/zoneless/index.js
@@ -1,19 +1,14 @@
-const angularCore = require('@angular/core');
-const { ErrorHandler, NgModule, VERSION, COMPILER_OPTIONS } = require('@angular/core');
+const { ErrorHandler, NgModule, COMPILER_OPTIONS, provideZonelessChangeDetection } = require('@angular/core');
 const { getTestBed } = require('@angular/core/testing');
 const { BrowserTestingModule, platformBrowserTesting } = require('@angular/platform-browser/testing');
 
 const { polyfillEncoder, resolveTestEnvOptions } = require('../utils');
-const provideZonelessChangeDetectionFn =
-    'provideExperimentalZonelessChangeDetection' in angularCore
-        ? angularCore.provideExperimentalZonelessChangeDetection
-        : angularCore.provideZonelessChangeDetection;
 
 const provideZonelessConfig = () => {
     class TestModule {}
     NgModule({
         providers: [
-            VERSION.major < 21 ? provideZonelessChangeDetectionFn() : null,
+            provideZonelessChangeDetection(),
             {
                 provide: ErrorHandler,
                 useValue: {
@@ -22,38 +17,27 @@ const provideZonelessConfig = () => {
                     },
                 },
             },
-        ].filter(Boolean),
+        ],
     })(TestModule);
 
     return TestModule;
 };
 
 const setupZonelessTestEnv = (options) => {
-    if (typeof provideZonelessChangeDetectionFn !== 'undefined') {
-        polyfillEncoder();
-        const resolvedOptions = resolveTestEnvOptions(options) ?? {};
-        const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
-        getTestBed().initTestEnvironment(
-            [BrowserTestingModule, provideZonelessConfig()],
-            platformBrowserTesting([
-                {
-                    provide: COMPILER_OPTIONS,
-                    useValue: {},
-                    multi: true,
-                },
-                ...extraProviders,
-            ]),
-            testEnvironmentOptions,
-        );
-
-        return;
-    }
-
-    throw Error(
-        `Cannot find ${
-            +VERSION.major >= 20 ? 'provideZonelessChangeDetection()' : 'provideExperimentalZonelessChangeDetection()'
-        } to setup zoneless testing environment. ` +
-            'Please use setupZoneTestEnv() from jest-preset-angular/setup-env/setup-zone-env.mjs instead.',
+    polyfillEncoder();
+    const resolvedOptions = resolveTestEnvOptions(options) ?? {};
+    const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
+    getTestBed().initTestEnvironment(
+        [BrowserTestingModule, provideZonelessConfig()],
+        platformBrowserTesting([
+            {
+                provide: COMPILER_OPTIONS,
+                useValue: {},
+                multi: true,
+            },
+            ...extraProviders,
+        ]),
+        testEnvironmentOptions,
     );
 };
 

--- a/setup-env/zoneless/index.mjs
+++ b/setup-env/zoneless/index.mjs
@@ -1,21 +1,14 @@
-import * as angularCore from '@angular/core';
-import { ErrorHandler, NgModule, VERSION, COMPILER_OPTIONS } from '@angular/core';
+import { ErrorHandler, NgModule, COMPILER_OPTIONS, provideZonelessChangeDetection } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
 import { polyfillEncoder, resolveTestEnvOptions } from '../utils';
 
-const provideZonelessChangeDetectionFn =
-    'provideExperimentalZonelessChangeDetection' in angularCore
-        ? // eslint-disable-next-line import/namespace
-          angularCore.provideExperimentalZonelessChangeDetection
-        : angularCore.provideZonelessChangeDetection;
-
 const provideZonelessConfig = () => {
     class TestModule {}
     NgModule({
         providers: [
-            VERSION.major < 21 ? provideZonelessChangeDetectionFn() : null,
+            provideZonelessChangeDetection(),
             {
                 provide: ErrorHandler,
                 useValue: {
@@ -24,38 +17,27 @@ const provideZonelessConfig = () => {
                     },
                 },
             },
-        ].filter(Boolean),
+        ],
     })(TestModule);
 
     return TestModule;
 };
 
 const setupZonelessTestEnv = (options) => {
-    if (typeof provideZonelessChangeDetectionFn !== 'undefined') {
-        polyfillEncoder();
-        const resolvedOptions = resolveTestEnvOptions(options) ?? {};
-        const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
-        getTestBed().initTestEnvironment(
-            [BrowserTestingModule, provideZonelessConfig()],
-            platformBrowserTesting([
-                {
-                    provide: COMPILER_OPTIONS,
-                    useValue: {},
-                    multi: true,
-                },
-                ...extraProviders,
-            ]),
-            testEnvironmentOptions,
-        );
-
-        return;
-    }
-
-    throw Error(
-        `Cannot find ${
-            +VERSION.major >= 20 ? 'provideZonelessChangeDetection()' : 'provideExperimentalZonelessChangeDetection()'
-        } to setup zoneless testing environment. ` +
-            'Please use setupZoneTestEnv() from jest-preset-angular/setup-env/setup-zone-env.mjs instead.',
+    polyfillEncoder();
+    const resolvedOptions = resolveTestEnvOptions(options) ?? {};
+    const { extraProviders = [], ...testEnvironmentOptions } = resolvedOptions;
+    getTestBed().initTestEnvironment(
+        [BrowserTestingModule, provideZonelessConfig()],
+        platformBrowserTesting([
+            {
+                provide: COMPILER_OPTIONS,
+                useValue: {},
+                multi: true,
+            },
+            ...extraProviders,
+        ]),
+        testEnvironmentOptions,
     );
 };
 

--- a/src/config/setup-env.spec.ts
+++ b/src/config/setup-env.spec.ts
@@ -36,12 +36,12 @@ jest.mock('@angular/platform-browser/testing', () => {
         platformBrowserTesting: mockPlatformBrowserTesting,
     };
 });
-const mockProvideExperimentalZonelessChangeDetection = jest.fn();
+const mockProvideZonelessChangeDetection = jest.fn();
 const mockProvideZoneChangeDetection = jest.fn();
 const mockCompilerOptions = 'COMPILER_OPTIONS';
 jest.mock('@angular/core', () => {
     return {
-        provideExperimentalZonelessChangeDetection: mockProvideExperimentalZonelessChangeDetection,
+        provideZonelessChangeDetection: mockProvideZonelessChangeDetection,
         provideZoneChangeDetection: mockProvideZoneChangeDetection,
         ErrorHandler: ErrorHandlerStub,
         NgModule: () => {
@@ -188,7 +188,7 @@ describe('Setup env utilities', () => {
             expect(mockZoneJs).not.toHaveBeenCalled();
             expect(mockZoneJsTesting).not.toHaveBeenCalled();
             assertOnInitTestEnv();
-            expect(mockProvideExperimentalZonelessChangeDetection).toHaveBeenCalled();
+            expect(mockProvideZonelessChangeDetection).toHaveBeenCalled();
         });
 
         it('should setup test environment with setupZonelessTestEnv() and extraProviders', async () => {
@@ -218,7 +218,7 @@ describe('Setup env utilities', () => {
                 },
                 mockProvider,
             ]);
-            expect(mockProvideExperimentalZonelessChangeDetection).toHaveBeenCalled();
+            expect(mockProvideZonelessChangeDetection).toHaveBeenCalled();
         });
 
         it('should resolve extraProviders from global testEnvironmentOptions for setupZonelessTestEnv()', async () => {
@@ -326,7 +326,7 @@ describe('Setup env utilities', () => {
             expect(mockZoneJs).not.toHaveBeenCalled();
             expect(mockZoneJsTesting).not.toHaveBeenCalled();
             assertOnInitTestEnv();
-            expect(mockProvideExperimentalZonelessChangeDetection).toHaveBeenCalled();
+            expect(mockProvideZonelessChangeDetection).toHaveBeenCalled();
         });
 
         it('should setup test environment with setupZonelessTestEnv() and extraProviders', async () => {
@@ -356,7 +356,7 @@ describe('Setup env utilities', () => {
                 },
                 mockProvider,
             ]);
-            expect(mockProvideExperimentalZonelessChangeDetection).toHaveBeenCalled();
+            expect(mockProvideZonelessChangeDetection).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## Summary

Remove legacy `provideExperimentalZonelessChangeDetection` detection and fallback from zoneless setup-env. Directly use `provideZonelessChangeDetection` which has been available since Angular 20.

## Test plan

Green CI

## Does this PR introduce a breaking change?

- Yes

## Other information

—