### PR TITLE
fix: renovate file change to update docusaurus dependencies correctly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,11 @@
       "rangeStrategy": "in-range-only"
     },
     {
+      "matchPaths": ["website/package.json"],
+      "matchPackagePatterns": ["^@docusaurus/", "^docusaurus"],
+      "rangeStrategy": "bump"
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "enabled": false
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Change to the renovate.json to update the docusaurus dependencies correctly and not leave out that in dependencies, as currently based on previous bumps as discussed in #3987 "devDependencies" are updated in /website just not the "dependencies" section.
Also tells renovate to update the caniuse-lite and baseline-browser-mapping packages to prevent this warning occuring when you build/start the example apps
<img width="893" height="236" alt="image" src="https://github.com/user-attachments/assets/81a4ab3b-c835-4c46-a54a-25a32ab987bd" />


## Test plan

Tests pass and if renovate says that this file is okay, on the next docusaurus version release it should also bump @docusaurus/core and other related dependencies

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
