### PR TITLE
fix: removed deprecated angular animations package

### DIFF
--- a/examples/example-app-monorepo/angular.json
+++ b/examples/example-app-monorepo/angular.json
@@ -45,12 +45,6 @@
                   "maximumError": "4kb"
                 }
               ],
-              "fileReplacements": [
-                {
-                  "replace": "apps/app1/src/environments/environment.ts",
-                  "with": "apps/app1/src/environments/environment.prod.ts"
-                }
-              ],
               "outputHashing": "all"
             },
             "development": {

--- a/examples/example-app-monorepo/package.json
+++ b/examples/example-app-monorepo/package.json
@@ -15,7 +15,6 @@
     "test-esm-isolated": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js -c jest-esm-isolated.config.ts --no-cache"
   },
   "dependencies": {
-    "@angular/animations": "^21.0.2",
     "@angular/common": "^21.2.19",
     "@angular/compiler": "^21.0.2",
     "@angular/core": "^21.0.7",

--- a/examples/example-app-monorepo/yarn.lock
+++ b/examples/example-app-monorepo/yarn.lock
@@ -213,17 +213,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/animations@npm:^21.0.2":
-  version: 21.2.19
-  resolution: "@angular/animations@npm:21.2.19"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/core": 21.2.19
-  checksum: 10/c016bae15a4210ca19db5930b563781b39225977959b55b14c9f7d5cf4f7631bee7435a06f51c5931d532fccb5c1877e15f0895e04f4b2a860326953355d34f8
-  languageName: node
-  linkType: hard
-
 "@angular/build@npm:^21.2.20":
   version: 21.2.20
   resolution: "@angular/build@npm:21.2.20"
@@ -4529,7 +4518,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-app-monorepo@workspace:."
   dependencies:
-    "@angular/animations": "npm:^21.0.2"
     "@angular/build": "npm:^21.2.20"
     "@angular/cli": "npm:^21.2.20"
     "@angular/common": "npm:^21.2.19"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "typescript": ">=5.8"
   },
   "devDependencies": {
-    "@angular/animations": "^22.1.0",
     "@angular/build": "^22.1.3",
     "@angular/cdk": "^22.1.1",
     "@angular/common": "^22.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,17 +175,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/animations@npm:^22.1.0":
-  version: 22.1.0
-  resolution: "@angular/animations@npm:22.1.0"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/core": 22.1.0
-  checksum: 10/263d5dd36db64301e3992d4412bffb27ec3d312b4d69fc0c0a00deaf65d350be8cfed636df0326eab424eef886dbf7b3a96768b82ecc5917e20116c6b7bb86f9
-  languageName: node
-  linkType: hard
-
 "@angular/build@npm:^22.1.3":
   version: 22.1.3
   resolution: "@angular/build@npm:22.1.3"
@@ -7551,7 +7540,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-preset-angular@workspace:."
   dependencies:
-    "@angular/animations": "npm:^22.1.0"
     "@angular/build": "npm:^22.1.3"
     "@angular/cdk": "npm:^22.1.1"
     "@angular/common": "npm:^22.1.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Removed deprecated angular animations package as detailed here: [https://angular.dev/guide/animations/migration](url)
Has been deprecated since v20.2 so removed it from the monorepo and main package.json

Note there is also a deprecations message in renovate: 

<img width="1833" height="999" alt="image" src="https://github.com/user-attachments/assets/c238ada7-d5f4-4e1c-9657-49f0ee4bd147" />


Also fixed monorepo app1 not building - note there is nothing at apps\app1\src\environments

<img width="572" height="25" alt="image" src="https://github.com/user-attachments/assets/2785db6d-a202-4c21-94af-c0df2b47c48e" />

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
