### PR TITLE
build(deps): update jest packages in dependencies to v30.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@jest/environment-jsdom-abstract": "^30.5.0",
+    "@jest/environment-jsdom-abstract": "^30.5.1",
     "bs-logger": "^0.2.6",
     "esbuild-wasm": ">=0.28.0",
-    "jest-util": "^30.5.0",
-    "pretty-format": "^30.5.0",
+    "jest-util": "^30.5.1",
+    "pretty-format": "^30.5.1",
     "ts-jest": "^29.4.12"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7553,11 +7553,11 @@ __metadata:
     husky: "npm:^9.1.7"
     jest: "npm:^30.5.1"
     jest-environment-jsdom: "npm:^30.5.1"
-    jest-util: "npm:^30.5.0"
+    jest-util: "npm:^30.5.1"
     jsdom: "npm:^26.1.0"
     pinst: "npm:^3.0.0"
     prettier: "npm:^3.9.6"
-    pretty-format: "npm:^30.5.0"
+    pretty-format: "npm:^30.5.1"
     rimraf: "npm:^5.0.10"
     rxjs: "npm:^7.8.2"
     semver: "npm:^7.8.5"
@@ -7703,7 +7703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:30.5.1, jest-util@npm:^30.5.0":
+"jest-util@npm:30.5.1, jest-util@npm:^30.5.1":
   version: 30.5.1
   resolution: "jest-util@npm:30.5.1"
   dependencies:
@@ -9152,7 +9152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:30.5.1, pretty-format@npm:^30.0.0, pretty-format@npm:^30.5.0":
+"pretty-format@npm:30.5.1, pretty-format@npm:^30.0.0, pretty-format@npm:^30.5.1":
   version: 30.5.1
   resolution: "pretty-format@npm:30.5.1"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Updating the jest dependencies to v30.5.1 as this is not done automatically by renovate

## Test plan

Tests pass

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
